### PR TITLE
Add npx makefaster CLI, loop skill, and real leaderboard submit APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+server/.data/
+.makefaster/
+*.tgz
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,21 +1,84 @@
 # Makefaster
 
-Marketing site for **Makefaster** — an AI skill that runs an autoresearch loop to
-continuously discover, test, and implement website performance improvements.
+**Makefaster** is an AI skill that runs an autoresearch loop to continuously
+discover, test, and implement website performance improvements — plus the
+marketing site and public leaderboards it reports to.
 
-Vanilla HTML/CSS/JS. No frameworks, no build step.
+The site is vanilla HTML/CSS/JS. No frameworks, no build step. The CLI and
+server are zero-dependency Node.
+
+## `npx makefaster`
+
+Run it inside a site repo:
+
+```bash
+npx makefaster            # or: npx github:jjcm/makefaster
+```
+
+What happens:
+
+1. **Detects the agent CLIs you already have** — Cursor Agent
+   (`cursor-agent`/`agent`), Claude Code (`claude`), Codex (`codex`) — via
+   PATH, well-known install locations (`~/.local/bin`, `~/.claude/local`,
+   `~/.cursor/bin`, Homebrew…), and explicit env overrides
+   (`CURSOR_AGENT_EXECUTABLE`, `CLAUDE_CODE_EXECUTABLE` /
+   `BB_CLAUDE_CODE_EXECUTABLE`, `CODEX_EXECUTABLE`). makefaster never bundles
+   or downloads a model; it drives your existing install. If none are found
+   it prints the real installers and exits.
+2. **Asks you to pick** among the CLIs actually found — before anything runs.
+3. **Imports the top-50 improvement categories** from the live leaderboard
+   (falling back to this repo's `data/improvements.json`) as a checklist of
+   likely wins — a guide, not a script.
+4. **Hands your repo to the agent** with the loop skill
+   ([`packages/skill/SKILL.md`](packages/skill/SKILL.md)): profile a
+   user-felt metric (Lighthouse if available; cold + warm; median of ≥3 runs),
+   then one hypothesis per iteration — measure, keep if it beats the noise
+   floor, revert otherwise.
+5. **Stops after 5 consecutive misses** (no serious improvement: ≥5% or
+   ≥20 ms on the north-star metric, and FCP-only wins that regress LCP don't
+   count), then shows the end screen with three questions:
+   - **Loop more?** — resets the miss counter and continues.
+   - **Submit stats to the Site leaderboard?** — your URL and favicon are
+     displayed publicly with the measured LCP/TTI improvements.
+   - **Submit anonymous improvements data?** — no URL; category names,
+     descriptions, and deltas only. Novel improvements become new categories
+     on the improvement leaderboard.
+
+```text
+Usage: npx makefaster [dir] [options]
+  --cli <cursor|claude|codex>   Skip the picker
+  --url <example.com>           Site URL for the leaderboard submission
+  --api <base>                  Leaderboard API base (default https://makefaster.dev)
+  --improvements <path|url>     Override the checklist source
+  --max-misses <n>              Stop after n straight misses (default 5)
+```
+
+Session state lives in `.makefaster/` in the target repo (auto-excluded from
+git via `.git/info/exclude`).
+
+## Skills
+
+| file | what |
+|---|---|
+| [`packages/skill/SKILL.md`](packages/skill/SKILL.md) | the **operational loop** the CLI hands to your agent: profiling rules, one-hypothesis iterations, the keep/revert bar, the 5-miss stop rule, and the `results.json` contract |
+| [`skill/SKILL.md`](skill/SKILL.md) | the **canonical technique catalog** — the updated [jjcm/speedupskill](https://github.com/jjcm/speedupskill) `SKILL.md` (measured wins, traps, keep/ditch discipline). Canonical here because a PR to that repo could not be opened from this environment; see [`skill/README.md`](skill/README.md) |
 
 ## Run locally
 
-The pages fetch local JSON, so serve the folder over HTTP (opening `index.html`
-directly via `file://` will not load data):
+Marketing pages only (reads the committed seed JSON):
 
 ```bash
 python3 -m http.server 8000
 # or: npx serve .
 ```
 
-Then open <http://localhost:8000>.
+Full stack — pages + live leaderboards + submit APIs:
+
+```bash
+node server/server.mjs        # http://localhost:8787
+```
+
+Then open <http://localhost:8000> (or `:8787`).
 
 ## Pages
 
@@ -25,31 +88,28 @@ Then open <http://localhost:8000>.
 | Site leaderboard | `site-leaderboard.html` |
 | Improvement leaderboard | `improvement-leaderboard.html` |
 
-## Easter egg: concrete backgrounds
+## Data APIs
 
-Press **C** anywhere (outside of a text input) to cycle through five seamless
-concrete background tiles (`assets/textures/concrete-0*.webp`): pale poured,
-board-formed, fine grit, polished cement, and weathered slab. The selected
-tile persists in `localStorage`.
+Real endpoints served by [`server/server.mjs`](server/README.md) — a
+zero-dependency Node process with a JSON-file store seeded from `data/`:
 
-## Data APIs (stubs for the upcoming skill)
+| Endpoint | What | Wrapper |
+|----------|------|---------|
+| `GET /data/sites.json` | live site rows (seed: 1,248 sites × cold/warm) | `MakefasterAPI.getSites()` |
+| `GET /data/improvements.json` | live ranked categories (seed: top 50) | `MakefasterAPI.getImprovements()` |
+| `POST /api/submit-site` | `{ url, favicon?, name?, lcpRaw, lcpDelta, ttiRaw, ttiDelta, mode: cold\|warm }` — upserts the site's row; URL + favicon shown publicly | `MakefasterAPI.submitSite(payload)` |
+| `POST /api/submit-improvements` | `{ improvements: [{ name, description?, deltaMs?, deltaPct? }] }` — anonymous; embedding-matched into categories (cosine similarity folds into the closest category or creates a new one) | `MakefasterAPI.submitImprovements(payload)` |
 
-The `npx makefaster` skill will read and write these. For now the reads are
-static JSON and the writes are client-side stubs that queue submissions in
-`localStorage` — see `js/api.js` for full payload documentation.
-
-| Endpoint | Now | Wrapper |
-|----------|-----|---------|
-| `GET data/sites.json` | static JSON (1,248 sites × cold/warm rows) | `MakefasterAPI.getSites()` |
-| `GET data/improvements.json` | static JSON (top 50 categories) | `MakefasterAPI.getImprovements()` |
-| `POST /api/submit-site` | localStorage stub | `MakefasterAPI.submitSite(payload)` |
-| `POST /api/submit-improvements` | localStorage stub | `MakefasterAPI.submitImprovements(payload)` |
+Deltas are percentages vs. baseline, negative = faster. Full contracts,
+embedding configuration (local hashing by default, optional OpenAI-compatible
+API via env key — no GPU either way), and deploy notes:
+[`server/README.md`](server/README.md).
 
 Row shapes:
 
 ```js
 // data/sites.json — one row per site per load mode
-{ "name": "Google", "url": "google.com", "favicon": "https://…", 
+{ "name": "Google", "url": "google.com", "favicon": "https://…",
   "lcpRaw": 1842, "lcpDelta": -34, "ttiRaw": 2945, "ttiDelta": -29,
   "mode": "cold", "tests": 6, "measuredAt": "2024-05-12T14:15:00Z" }
 
@@ -60,11 +120,24 @@ Row shapes:
   "icon": "gzip" }
 ```
 
-Regenerate the stub datasets (deterministic, seeded):
+Regenerate the seed datasets (deterministic, seeded):
 
 ```bash
 node scripts/generate-data.mjs
 ```
+
+## Tests
+
+```bash
+npm test    # node --test — CLI detection/args/payloads + server API/embedding/store
+```
+
+## Easter egg: concrete backgrounds
+
+Press **C** anywhere (outside of a text input) to cycle through five seamless
+concrete background tiles (`assets/textures/concrete-0*.webp`): pale poured,
+board-formed, fine grit, polished cement, and weathered slab. The selected
+tile persists in `localStorage`.
 
 ## Assets
 

--- a/js/api.js
+++ b/js/api.js
@@ -1,30 +1,35 @@
 /**
- * Makefaster data API — tiny fetch wrappers + client-side submission stubs.
+ * Makefaster data API — fetch wrappers over the real endpoints.
  *
- * Read endpoints (static JSON, live now):
+ * Read endpoints:
  *   GET data/sites.json         -> MakefasterAPI.getSites()
  *   GET data/improvements.json  -> MakefasterAPI.getImprovements()
+ *   Served live from the leaderboard store when the site runs behind
+ *   `node server/server.mjs`; a dumb file server (python3 -m http.server)
+ *   serves the committed seed JSON instead, so the marketing pages always
+ *   render.
  *
- * Write endpoints (client stubs, localStorage-backed for now):
+ * Write endpoints (the `npx makefaster` skill posts these; the pages only
+ * read):
  *   POST /api/submit-site          -> MakefasterAPI.submitSite(payload)
  *   POST /api/submit-improvements  -> MakefasterAPI.submitImprovements(payload)
  *
- * The submit stubs append to localStorage so the autoresearch skill can be
- * developed against the final payload shapes before the real backend exists.
- * A later pass swaps their internals for real fetch() POSTs with the same
- * signatures and return shapes.
+ * When the static pages are hosted apart from the API (e.g. GitHub Pages +
+ * a deployed server), set the API origin before this script loads:
+ *   <script>window.MAKEFASTER_API_BASE = "https://api.example.com";</script>
+ * Same-origin relative paths are used otherwise.
  */
 (function (global) {
   "use strict";
 
+  function apiBase() {
+    var base = global.MAKEFASTER_API_BASE || "";
+    return base.replace(/\/$/, "");
+  }
+
   var DATA_URLS = {
     sites: "data/sites.json",
     improvements: "data/improvements.json",
-  };
-
-  var STORE_KEYS = {
-    sites: "makefaster.submissions.sites",
-    improvements: "makefaster.submissions.improvements",
   };
 
   function getJson(url) {
@@ -34,10 +39,29 @@
     });
   }
 
+  function postJson(path, payload) {
+    var url = apiBase() + path;
+    return fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(payload),
+    }).then(function (res) {
+      return res.json().catch(function () {
+        return {};
+      }).then(function (body) {
+        if (!res.ok) {
+          var reason = body && body.errors ? body.errors.join("; ") : "HTTP " + res.status;
+          throw new Error("POST " + path + " failed: " + reason);
+        }
+        return body;
+      });
+    });
+  }
+
   /**
    * Site leaderboard rows.
-   * Row shape: { url, favicon, lcpRaw, lcpDelta, ttiRaw, ttiDelta, mode }
-   * (plus optional extras this stub dataset also carries: name, tests, measuredAt)
+   * Row shape: { name, url, favicon, lcpRaw, lcpDelta, ttiRaw, ttiDelta,
+   *              mode, tests, measuredAt }
    * lcpDelta / ttiDelta are percentages vs. baseline (negative = faster).
    * mode is "cold" or "warm".
    */
@@ -46,27 +70,13 @@
   }
 
   /**
-   * Improvement leaderboard categories (top 50).
-   * Shape: { name, count, avgImprovementMs, avgImprovementPct }
-   * (plus optional extras: rank, description, icon)
+   * Improvement leaderboard categories, ranked (top 50 seeded; community
+   * submissions can grow the list).
+   * Shape: { rank, name, description, count, avgImprovementMs,
+   *          avgImprovementPct, icon }
    */
   function getImprovements() {
     return getJson(DATA_URLS.improvements);
-  }
-
-  function readStore(key) {
-    try {
-      return JSON.parse(localStorage.getItem(key)) || [];
-    } catch (err) {
-      return [];
-    }
-  }
-
-  function appendStore(key, entry) {
-    var all = readStore(key);
-    all.push(entry);
-    localStorage.setItem(key, JSON.stringify(all));
-    return all.length;
   }
 
   function assertFields(payload, fields, label) {
@@ -82,24 +92,22 @@
   }
 
   /**
-   * Stub for POST /api/submit-site — one measurement run for one site.
+   * POST /api/submit-site — one measurement run for one site. The URL and
+   * favicon are displayed on the public site leaderboard.
    *
-   * Payload shape:
+   * Payload:
    * {
-   *   url:      "example.com",        // required — bare domain
+   *   url:      "example.com",        // required — bare domain (scheme ok)
    *   mode:     "cold" | "warm",      // required
    *   lcpRaw:   1842,                 // required — ms
    *   lcpDelta: -34,                  // required — % vs. baseline (negative = faster)
    *   ttiRaw:   2945,                 // required — ms
    *   ttiDelta: -29,                  // required — % vs. baseline
-   *   name:      "Example",           // optional display name
-   *   favicon:   "https://...",       // optional favicon URL
-   *   tests:     6,                   // optional test-run count
-   *   measuredAt:"2024-05-12T14:15:00Z" // optional ISO timestamp
+   *   name:     "Example",            // optional display name
+   *   favicon:  "https://..."         // optional favicon URL
    * }
    *
-   * Resolves { ok: true, endpoint, queued } where queued is the number of
-   * submissions currently held in localStorage.
+   * Resolves the server response: { ok, created, row }.
    */
   function submitSite(payload) {
     var invalid = assertFields(payload, ["url", "mode", "lcpRaw", "lcpDelta", "ttiRaw", "ttiDelta"], "submitSite");
@@ -107,47 +115,49 @@
     if (payload.mode !== "cold" && payload.mode !== "warm") {
       return Promise.reject(new Error("submitSite: mode must be 'cold' or 'warm'"));
     }
-    var queued = appendStore(STORE_KEYS.sites, {
-      payload: payload,
-      receivedAt: new Date().toISOString(),
-    });
-    return Promise.resolve({ ok: true, endpoint: "/api/submit-site", queued: queued });
+    return postJson("/api/submit-site", payload);
   }
 
   /**
-   * Stub for POST /api/submit-improvements — improvements applied to one site.
+   * POST /api/submit-improvements — anonymous by design: no URL, no site
+   * identity, just what was improved and by how much. The server embeds each
+   * entry and either folds it into the closest existing category (cosine
+   * similarity above threshold) or creates a new category on the improvement
+   * leaderboard.
    *
-   * Payload shape:
+   * Payload:
    * {
-   *   url: "example.com",                   // required
-   *   improvements: [                       // required, at least one entry
+   *   improvements: [                  // required, 1–50 entries
    *     {
-   *       category:  "Gzip / Brotli Compression", // required — category name
-   *       deltaMs:   -412,                  // optional — ms saved (negative = faster)
-   *       deltaPct:  -28.6,                 // optional — % vs. baseline
-   *       appliedAt: "2024-05-12T14:15:00Z" // optional ISO timestamp
-   *     }
+   *       name:        "Inline critical CSS",   // required
+   *       description: "Inlined above-the-fold styles", // recommended
+   *       deltaMs:     -120,           // ms saved (negative = faster)
+   *       deltaPct:    -8.5            // % vs. baseline (negative = faster)
+   *     }                              // at least one delta required
    *   ]
    * }
    *
-   * Resolves { ok: true, endpoint, queued }.
+   * Resolves the server response:
+   * { ok, results: [{ input, action: "matched"|"created", category, similarity }],
+   *   embedder, threshold }.
    */
   function submitImprovements(payload) {
-    var invalid = assertFields(payload, ["url", "improvements"], "submitImprovements");
+    var invalid = assertFields(payload, ["improvements"], "submitImprovements");
     if (invalid) return invalid;
     if (!Array.isArray(payload.improvements) || payload.improvements.length === 0) {
       return Promise.reject(new Error("submitImprovements: improvements must be a non-empty array"));
     }
     for (var i = 0; i < payload.improvements.length; i++) {
-      if (!payload.improvements[i] || !payload.improvements[i].category) {
-        return Promise.reject(new Error("submitImprovements: improvements[" + i + "] is missing 'category'"));
+      var entry = payload.improvements[i];
+      if (!entry || !entry.name) {
+        return Promise.reject(new Error("submitImprovements: improvements[" + i + "] is missing 'name'"));
+      }
+      if ((entry.deltaMs === undefined || entry.deltaMs === null) &&
+          (entry.deltaPct === undefined || entry.deltaPct === null)) {
+        return Promise.reject(new Error("submitImprovements: improvements[" + i + "] needs deltaMs or deltaPct"));
       }
     }
-    var queued = appendStore(STORE_KEYS.improvements, {
-      payload: payload,
-      receivedAt: new Date().toISOString(),
-    });
-    return Promise.resolve({ ok: true, endpoint: "/api/submit-improvements", queued: queued });
+    return postJson("/api/submit-improvements", payload);
   }
 
   global.MakefasterAPI = {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "makefaster",
+  "version": "0.1.0",
+  "description": "AI skill that runs an autoresearch loop to make your site measurably faster. `npx makefaster` drives the agent CLI you already have (Cursor, Claude Code, or Codex) through profile -> hypothesis -> measure -> keep/revert iterations, then submits results to the public leaderboards.",
+  "type": "module",
+  "bin": {
+    "makefaster": "packages/cli/bin/makefaster.js"
+  },
+  "files": [
+    "packages/cli",
+    "packages/skill",
+    "data/improvements.json"
+  ],
+  "scripts": {
+    "test": "node --test packages/cli/test/*.test.mjs server/test/*.test.mjs",
+    "serve": "node server/server.mjs",
+    "site": "python3 -m http.server 8000"
+  },
+  "engines": {
+    "node": ">=18.17"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jjcm/makefaster.git"
+  },
+  "homepage": "https://github.com/jjcm/makefaster#readme",
+  "keywords": [
+    "performance",
+    "lighthouse",
+    "lcp",
+    "agent",
+    "skill",
+    "autoresearch"
+  ]
+}

--- a/packages/cli/bin/makefaster.js
+++ b/packages/cli/bin/makefaster.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+/**
+ * npx makefaster — run the autoresearch performance loop against the site in
+ * the current directory, driving an agent CLI you already have installed
+ * (Cursor Agent, Claude Code, or Codex). See packages/skill/SKILL.md for the
+ * loop itself and README.md for the full flow.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { USAGE, parseArgs } from "../lib/args.js";
+import { resolveApiBase } from "../lib/apiClient.js";
+import { detectProviders, missingCliGuidance } from "../lib/detect.js";
+import { runEndScreen } from "../lib/endscreen.js";
+import { importChecklist } from "../lib/improvements.js";
+import { confirm, selectFrom } from "../lib/picker.js";
+import {
+  continuePrompt,
+  kickoffPrompt,
+  prepareSession,
+  readResults,
+  runAgent,
+  writeState,
+} from "../lib/session.js";
+import { ARROW, FAIL, OK, banner, bold, cyan, dim, red, yellow } from "../lib/ui.js";
+
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const VERSION = JSON.parse(readFileSync(join(PACKAGE_ROOT, "package.json"), "utf8")).version;
+
+function fail(message, code = 1) {
+  console.error(`${FAIL} ${red(message)}`);
+  process.exit(code);
+}
+
+async function pickProvider(reports, cliFlag) {
+  const found = reports.filter((r) => r.found);
+
+  if (cliFlag) {
+    const wanted = reports.find((r) => r.key === cliFlag);
+    if (!wanted.found) {
+      fail(`--cli ${cliFlag}: ${wanted.displayName} was not found on this machine.\n` +
+        (wanted.error ? `  ${wanted.error}\n` : "") +
+        `  install it with: ${wanted.install}`);
+    }
+    return wanted;
+  }
+
+  if (found.length === 0) {
+    console.error(missingCliGuidance(reports));
+    process.exit(1);
+  }
+
+  console.log(`  ${bold("Detected agent CLIs")} ${dim("(makefaster drives your existing install — no bundled model)")}`);
+  for (const report of reports) {
+    if (report.found) {
+      console.log(`    ${OK} ${report.displayName.padEnd(14)} ${dim(report.executablePath)}${report.version ? dim(`  (${report.version})`) : ""}`);
+    } else {
+      const note = report.error || report.hint || `not found — install: ${report.install}`;
+      console.log(`    ${dim("-")} ${dim(report.displayName.padEnd(14))} ${dim(note)}`);
+    }
+  }
+  console.log("");
+
+  if (found.length === 1) {
+    if (process.stdin.isTTY) {
+      const useIt = await confirm(`  Use ${bold(found[0].displayName)}?`, { def: true });
+      if (!useIt) process.exit(0);
+    } else {
+      console.log(dim(`  (non-interactive: using the only CLI found, ${found[0].displayName})`));
+    }
+    return found[0];
+  }
+
+  try {
+    const index = await selectFrom({
+      title: `  ${bold("Which agent CLI should run the loop?")}`,
+      options: found.map((report) => ({
+        label: report.displayName,
+        detail: `${report.executablePath}${report.version ? ` — ${report.version}` : ""}`,
+      })),
+    });
+    if (index === null) process.exit(0);
+    return found[index];
+  } catch (err) {
+    if (err.code === "NO_TTY") {
+      fail(`multiple agent CLIs found (${found.map((r) => r.key).join(", ")}) but stdin is not a TTY — pass --cli <${found.map((r) => r.key).join("|")}>`, 2);
+    }
+    throw err;
+  }
+}
+
+async function main() {
+  const { args, errors } = parseArgs(process.argv.slice(2));
+  if (errors.length > 0) {
+    console.error(errors.map((e) => `${FAIL} ${e}`).join("\n") + "\n\n" + USAGE);
+    process.exit(2);
+  }
+  if (args.help) { console.log(USAGE); return; }
+  if (args.version) { console.log(VERSION); return; }
+
+  const cwd = resolve(args.targetDir || process.cwd());
+  if (!existsSync(cwd)) fail(`target directory does not exist: ${cwd}`);
+
+  console.log(banner(VERSION));
+
+  // 1. Detect installed agent CLIs and let the user pick BEFORE anything runs.
+  const reports = detectProviders();
+  const provider = await pickProvider(reports, args.cli);
+  console.log(`  ${OK} using ${bold(provider.displayName)} ${dim(provider.executablePath)}\n`);
+
+  // 2. Import the top-50 improvement checklist (live board -> GitHub -> local fallback).
+  const apiBase = resolveApiBase({ flag: args.api });
+  let checklist;
+  try {
+    checklist = await importChecklist({ override: args.improvementsSource, apiBase, cwd });
+  } catch (err) {
+    fail(err.message);
+  }
+  console.log(`  ${OK} imported ${bold(checklist.categories.length)} improvement categories ${dim(`from ${checklist.source}`)}\n`);
+
+  if (!existsSync(join(cwd, ".git"))) {
+    console.log(yellow("  note: this directory is not a git repo — the loop relies on git for"));
+    console.log(yellow("  clean keep/revert; the skill will fall back to file snapshots.\n"));
+  }
+
+  // 3. Prepare the session contract in .makefaster/ and hand off to the agent.
+  const { paths, state } = prepareSession({
+    cwd,
+    provider,
+    checklist: checklist.categories,
+    checklistSource: checklist.source,
+    apiBase,
+    maxMisses: args.maxMisses,
+    siteUrl: args.url,
+  });
+
+  let prompt = kickoffPrompt();
+  for (;;) {
+    console.log(`  ${cyan(ARROW)} handing off to ${bold(provider.displayName)} ${dim(`(round ${state.round})`)} — the loop runs in its session; exit it to come back here.\n`);
+    const { exitCode } = runAgent({ provider, prompt, cwd });
+    if (exitCode !== 0) {
+      console.log(yellow(`\n  ${provider.displayName} exited with code ${exitCode}.`));
+    }
+
+    // 4. End screen: summary + the three questions.
+    const results = readResults(cwd);
+    const { loopMore } = await runEndScreen({ results, state, paths });
+    if (!loopMore) break;
+
+    state.missStreak = 0;
+    state.round += 1;
+    writeState(cwd, state);
+    if (results && !results.parseError) {
+      results.missStreak = 0;
+      results.stoppedReason = null;
+      try {
+        const { writeFileSync } = await import("node:fs");
+        writeFileSync(paths.results, JSON.stringify(results, null, 2) + "\n");
+      } catch { /* the agent re-reads state.json either way */ }
+    }
+    prompt = continuePrompt();
+  }
+}
+
+main().catch((err) => {
+  fail(err?.stack || String(err));
+});

--- a/packages/cli/lib/apiClient.js
+++ b/packages/cli/lib/apiClient.js
@@ -1,0 +1,95 @@
+/**
+ * Leaderboard submission client + the pure builders that turn a session's
+ * results.json into the two endpoint payloads.
+ */
+
+export const DEFAULT_API_BASE = "https://makefaster.dev";
+const SUBMIT_TIMEOUT_MS = 10_000;
+const MAX_IMPROVEMENTS = 50;
+
+export function resolveApiBase({ flag, env = process.env } = {}) {
+  return (flag || env.MAKEFASTER_API_BASE || DEFAULT_API_BASE).replace(/\/$/, "");
+}
+
+async function postJson(apiBase, path, payload) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), SUBMIT_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${apiBase}${path}`, {
+      method: "POST",
+      headers: { "content-type": "application/json", accept: "application/json" },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+    const body = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      const reason = Array.isArray(body.errors) ? body.errors.join("; ") : `HTTP ${res.status}`;
+      throw new Error(`POST ${path} failed: ${reason}`);
+    }
+    return body;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function submitSite(apiBase, payload) {
+  return postJson(apiBase, "/api/submit-site", payload);
+}
+
+export function submitImprovements(apiBase, payload) {
+  return postJson(apiBase, "/api/submit-improvements", payload);
+}
+
+function pctChange(baseline, final) {
+  if (!(baseline > 0)) return null;
+  return Math.round(((final - baseline) / baseline) * 1000) / 10;
+}
+
+function modePayload(results, mode, siteUrl) {
+  const baseline = results?.baseline?.[mode];
+  const final = results?.final?.[mode];
+  const values = [baseline?.lcpMs, baseline?.ttiMs, final?.lcpMs, final?.ttiMs];
+  if (values.some((v) => typeof v !== "number" || !Number.isFinite(v))) return null;
+  const lcpDelta = pctChange(baseline.lcpMs, final.lcpMs);
+  const ttiDelta = pctChange(baseline.ttiMs, final.ttiMs);
+  if (lcpDelta === null || ttiDelta === null) return null;
+  return {
+    url: siteUrl,
+    mode,
+    lcpRaw: Math.round(final.lcpMs),
+    lcpDelta,
+    ttiRaw: Math.round(final.ttiMs),
+    ttiDelta,
+    ...(results?.site?.name ? { name: results.site.name } : {}),
+    ...(results?.site?.favicon ? { favicon: results.site.favicon } : {}),
+  };
+}
+
+/**
+ * One submit-site payload per mode that has complete baseline+final numbers.
+ * Deltas are computed here (percent vs. baseline, negative = faster) so the
+ * skill only ever reports raw measurements.
+ */
+export function buildSitePayloads(results, siteUrl) {
+  return ["cold", "warm"]
+    .map((mode) => modePayload(results, mode, siteUrl))
+    .filter(Boolean);
+}
+
+/**
+ * The anonymous improvements payload: kept iterations only, no URL, no site
+ * identity — just names, descriptions, and measured deltas.
+ */
+export function buildImprovementsPayload(results) {
+  const kept = (results?.iterations || [])
+    .filter((it) => it && it.kept === true && it.name)
+    .filter((it) => typeof it.deltaMs === "number" || typeof it.deltaPct === "number")
+    .slice(0, MAX_IMPROVEMENTS)
+    .map((it) => ({
+      name: String(it.name).slice(0, 120),
+      description: String(it.description || "").slice(0, 500),
+      ...(typeof it.deltaMs === "number" ? { deltaMs: it.deltaMs } : {}),
+      ...(typeof it.deltaPct === "number" ? { deltaPct: it.deltaPct } : {}),
+    }));
+  return kept.length > 0 ? { improvements: kept } : null;
+}

--- a/packages/cli/lib/args.js
+++ b/packages/cli/lib/args.js
@@ -1,0 +1,109 @@
+/**
+ * Argument parsing for `npx makefaster [dir] [flags]`. Hand-rolled so the CLI
+ * stays dependency-free.
+ */
+
+export const USAGE = `Usage: npx makefaster [dir] [options]
+
+Runs the makefaster autoresearch loop against the site in [dir] (default:
+the current directory), driving an agent CLI you already have installed.
+
+Options:
+  --cli <cursor|claude|codex>   Skip the picker and use this agent CLI
+  --url <example.com>           The public URL of the site (used for the
+                                site-leaderboard submission)
+  --api <base>                  Leaderboard API base
+                                (default: $MAKEFASTER_API_BASE or https://makefaster.dev)
+  --improvements <path|url>     Override the improvement-checklist source
+  --max-misses <n>              Stop after n consecutive missed iterations (default 5)
+  -h, --help                    Show this help
+  -v, --version                 Print the version
+
+Environment:
+  CURSOR_AGENT_EXECUTABLE, CLAUDE_CODE_EXECUTABLE (or BB_CLAUDE_CODE_EXECUTABLE),
+  CODEX_EXECUTABLE               Explicit paths to agent CLI binaries
+  MAKEFASTER_API_BASE            Leaderboard API base
+  NO_COLOR                       Disable colors
+`;
+
+const CLI_ALIASES = new Map([
+  ["cursor", "cursor"], ["cursor-agent", "cursor"], ["agent", "cursor"],
+  ["claude", "claude"], ["claude-code", "claude"], ["claudecode", "claude"],
+  ["codex", "codex"],
+]);
+
+export function parseArgs(argv) {
+  const args = {
+    targetDir: null,
+    cli: null,
+    url: null,
+    api: null,
+    improvementsSource: null,
+    maxMisses: 5,
+    help: false,
+    version: false,
+  };
+  const errors = [];
+
+  const takeValue = (list, i, flag) => {
+    const value = list[i + 1];
+    if (value === undefined || value.startsWith("-")) {
+      errors.push(`${flag} needs a value`);
+      return null;
+    }
+    return value;
+  };
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    switch (arg) {
+      case "-h": case "--help": args.help = true; break;
+      case "-v": case "--version": args.version = true; break;
+      case "--cli": {
+        const value = takeValue(argv, i, "--cli");
+        if (value !== null) {
+          i++;
+          const key = CLI_ALIASES.get(value.toLowerCase());
+          if (!key) errors.push(`--cli must be one of: cursor, claude, codex (got "${value}")`);
+          else args.cli = key;
+        }
+        break;
+      }
+      case "--url": {
+        const value = takeValue(argv, i, "--url");
+        if (value !== null) { i++; args.url = value; }
+        break;
+      }
+      case "--api": {
+        const value = takeValue(argv, i, "--api");
+        if (value !== null) { i++; args.api = value.replace(/\/$/, ""); }
+        break;
+      }
+      case "--improvements": {
+        const value = takeValue(argv, i, "--improvements");
+        if (value !== null) { i++; args.improvementsSource = value; }
+        break;
+      }
+      case "--max-misses": {
+        const value = takeValue(argv, i, "--max-misses");
+        if (value !== null) {
+          i++;
+          const n = Number.parseInt(value, 10);
+          if (!Number.isInteger(n) || n < 1 || n > 100) errors.push("--max-misses must be an integer between 1 and 100");
+          else args.maxMisses = n;
+        }
+        break;
+      }
+      default:
+        if (arg.startsWith("-")) {
+          errors.push(`unknown option "${arg}"`);
+        } else if (args.targetDir === null) {
+          args.targetDir = arg;
+        } else {
+          errors.push(`unexpected argument "${arg}"`);
+        }
+    }
+  }
+
+  return { args, errors };
+}

--- a/packages/cli/lib/detect.js
+++ b/packages/cli/lib/detect.js
@@ -1,0 +1,265 @@
+/**
+ * Detect the inference/agent CLIs already installed on this machine, the way
+ * bb / get-bb does: makefaster never vendors a model or starts an inference
+ * server — it piggybacks on the agent CLIs the user already has and is
+ * signed into.
+ *
+ * Per provider, in order:
+ *   1. explicit env override (e.g. CLAUDE_CODE_EXECUTABLE / the documented
+ *      BB_CLAUDE_CODE_EXECUTABLE) — if set but not executable, the provider
+ *      is reported with an error instead of silently falling through;
+ *   2. a PATH scan for the provider's executable names (executable regular
+ *      files only, symlinks followed);
+ *   3. well-known install locations (~/.local/bin, ~/.claude/local,
+ *      ~/.cursor/bin, Homebrew, /usr/local/bin, beside the running node for
+ *      npm-global installs) — skipped when running as root so a user-writable
+ *      binary is never picked up with elevated privileges (root can still use
+ *      the env overrides);
+ *   4. config-home hints (~/.cursor, ~/.claude, CODEX_HOME or ~/.codex) are
+ *      reported as evidence ("config found, binary missing") but never launch
+ *      anything by themselves.
+ */
+
+import { accessSync, constants, realpathSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { delimiter, dirname, join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const VERSION_PROBE_TIMEOUT_MS = 5_000;
+
+export const PROVIDERS = [
+  {
+    key: "cursor",
+    displayName: "Cursor Agent",
+    // `cursor-agent` is the installed binary; newer installs also expose a
+    // bare `agent`. The bare name is generic, so an `agent` hit must prove it
+    // is Cursor's (resolved path or --version mentions cursor) before use.
+    executables: ["cursor-agent", "agent"],
+    envOverrides: ["MAKEFASTER_CURSOR_EXECUTABLE", "CURSOR_AGENT_EXECUTABLE"],
+    wellKnown: ({ home }) => [
+      join(home, ".local", "bin", "cursor-agent"),
+      join(home, ".cursor", "bin", "cursor-agent"),
+      "/opt/homebrew/bin/cursor-agent",
+      "/usr/local/bin/cursor-agent",
+    ],
+    homeHints: ({ home }) => [join(home, ".cursor")],
+    install: "curl https://cursor.com/install -fsS | bash",
+    validateAmbiguousName: (name, { resolvedPath, versionOutput }) => {
+      if (name !== "agent") return true;
+      return /cursor/i.test(resolvedPath) || /cursor/i.test(versionOutput || "");
+    },
+  },
+  {
+    key: "claude",
+    displayName: "Claude Code",
+    executables: ["claude"],
+    envOverrides: ["CLAUDE_CODE_EXECUTABLE", "BB_CLAUDE_CODE_EXECUTABLE"],
+    wellKnown: ({ home }) => [
+      join(home, ".local", "bin", "claude"),
+      join(home, ".claude", "local", "claude"),
+      "/opt/homebrew/bin/claude",
+      "/usr/local/bin/claude",
+    ],
+    homeHints: ({ home }) => [join(home, ".claude")],
+    install: "curl -fsSL https://claude.ai/install.sh | bash   (or: npm install -g @anthropic-ai/claude-code)",
+  },
+  {
+    key: "codex",
+    displayName: "Codex",
+    executables: ["codex"],
+    envOverrides: ["MAKEFASTER_CODEX_EXECUTABLE", "CODEX_EXECUTABLE"],
+    wellKnown: ({ home, execDir }) => [
+      join(home, ".local", "bin", "codex"),
+      "/opt/homebrew/bin/codex",
+      "/usr/local/bin/codex",
+      // npm -g installs land beside the node binary under nvm/volta/asdf.
+      ...(execDir ? [join(execDir, "codex")] : []),
+    ],
+    homeHints: ({ home, env }) => [env.CODEX_HOME || join(home, ".codex")],
+    install: "npm install -g @openai/codex",
+  },
+];
+
+function isExecutableFile(candidatePath) {
+  try {
+    accessSync(candidatePath, constants.X_OK);
+    return statSync(candidatePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function windowsCandidates(basePath, env) {
+  const pathext = (env.PATHEXT || ".EXE;.CMD;.BAT;.COM").split(";").filter(Boolean);
+  return [basePath, ...pathext.map((ext) => basePath + ext.toLowerCase()), ...pathext.map((ext) => basePath + ext)];
+}
+
+function resolveOnPath(executableName, { env, platform }) {
+  const pathEnv = env.PATH || env.Path || "";
+  for (const searchDir of pathEnv.split(delimiter)) {
+    if (!searchDir) continue;
+    const base = join(searchDir, executableName);
+    const candidates = platform === "win32" ? windowsCandidates(base, env) : [base];
+    for (const candidate of candidates) {
+      if (isExecutableFile(candidate)) return candidate;
+    }
+  }
+  return null;
+}
+
+function directoryExists(path) {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function defaultProbeVersion(executablePath) {
+  try {
+    const result = spawnSync(executablePath, ["--version"], {
+      encoding: "utf8",
+      timeout: VERSION_PROBE_TIMEOUT_MS,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const output = `${result.stdout || ""}\n${result.stderr || ""}`;
+    const line = output.split(/\r?\n/).map((l) => l.trim()).find((l) => l.length > 0);
+    return { ok: result.status === 0, version: line ? line.slice(0, 60) : null, output };
+  } catch {
+    return { ok: false, version: null, output: "" };
+  }
+}
+
+function safeRealpath(path) {
+  try {
+    return realpathSync(path);
+  } catch {
+    return path;
+  }
+}
+
+/**
+ * @param {object} [options] test injection points
+ * @param {NodeJS.ProcessEnv} [options.env]
+ * @param {string} [options.platform]
+ * @param {string} [options.home]
+ * @param {boolean} [options.isRoot]
+ * @param {string|null} [options.execDir] directory of the running node binary
+ * @param {(path: string) => {ok: boolean, version: string|null, output: string}} [options.probeVersion]
+ * @returns {Array<{key, displayName, install, found, executablePath, source, version, error, hint}>}
+ */
+export function detectProviders(options = {}) {
+  const env = options.env ?? process.env;
+  const platform = options.platform ?? process.platform;
+  const home = options.home ?? env.HOME ?? homedir();
+  const isRoot = options.isRoot ?? (typeof process.getuid === "function" ? process.getuid() === 0 : false);
+  const execDir = options.execDir === undefined ? dirname(process.execPath) : options.execDir;
+  const probeVersion = options.probeVersion ?? defaultProbeVersion;
+
+  return PROVIDERS.map((provider) => {
+    const report = {
+      key: provider.key,
+      displayName: provider.displayName,
+      install: provider.install,
+      found: false,
+      executablePath: null,
+      source: null,
+      version: null,
+      error: null,
+      hint: null,
+    };
+
+    // 1. Explicit env override — a broken override is an error the user must
+    //    see, not something to silently skip (bb behaves the same way).
+    for (const envName of provider.envOverrides) {
+      const value = env[envName]?.trim();
+      if (!value) continue;
+      if (isExecutableFile(value)) {
+        report.found = true;
+        report.executablePath = value;
+        report.source = `env:${envName}`;
+      } else {
+        report.error = `${envName} is set but does not point to an executable file: ${value}`;
+      }
+      break;
+    }
+
+    // 2. PATH scan.
+    if (!report.found && !report.error) {
+      for (const executableName of provider.executables) {
+        const onPath = resolveOnPath(executableName, { env, platform });
+        if (!onPath) continue;
+        if (provider.validateAmbiguousName) {
+          const resolvedPath = safeRealpath(onPath);
+          let versionOutput = "";
+          if (!/cursor/i.test(resolvedPath)) {
+            versionOutput = probeVersion(onPath).output;
+          }
+          if (!provider.validateAmbiguousName(executableName, { resolvedPath, versionOutput })) {
+            continue; // some unrelated `agent` binary — not ours to launch
+          }
+        }
+        report.found = true;
+        report.executablePath = onPath;
+        report.source = "path";
+        break;
+      }
+    }
+
+    // 3. Well-known install locations (never as root).
+    if (!report.found && !report.error && !isRoot) {
+      for (const candidate of provider.wellKnown({ home, env, execDir })) {
+        if (isExecutableFile(candidate)) {
+          report.found = true;
+          report.executablePath = candidate;
+          report.source = "well-known";
+          break;
+        }
+      }
+    }
+
+    // 4. Config-home evidence for the "not found" message.
+    if (!report.found) {
+      for (const hintPath of provider.homeHints({ home, env })) {
+        if (directoryExists(hintPath)) {
+          report.hint = `${hintPath} exists — ${provider.displayName} has been used here, but no runnable binary was found`;
+          break;
+        }
+      }
+    }
+
+    // Version banner for the picker.
+    if (report.found) {
+      const probe = probeVersion(report.executablePath);
+      if (probe.version) report.version = probe.version;
+    }
+
+    return report;
+  });
+}
+
+/** The user-facing "nothing installed" guidance, in bb's missing-CLI tone. */
+export function missingCliGuidance(reports) {
+  const lines = [
+    "makefaster could not find any supported agent CLI on this machine.",
+    "",
+    "makefaster does not bundle or download a model — it drives an agent CLI",
+    "you already have and are signed into. Install one of these, then run",
+    "`npx makefaster` again:",
+    "",
+  ];
+  for (const report of reports) {
+    lines.push(`  ${report.displayName.padEnd(14)}${report.install}`);
+  }
+  lines.push("");
+  const hints = reports.filter((r) => r.hint).map((r) => `  note: ${r.hint}`);
+  if (hints.length > 0) lines.push(...hints, "");
+  const errors = reports.filter((r) => r.error).map((r) => `  error: ${r.error}`);
+  if (errors.length > 0) lines.push(...errors, "");
+  lines.push(
+    "If your CLI lives somewhere unusual, point makefaster at it with",
+    "CURSOR_AGENT_EXECUTABLE, CLAUDE_CODE_EXECUTABLE (BB_CLAUDE_CODE_EXECUTABLE",
+    "works too), or CODEX_EXECUTABLE.",
+  );
+  return lines.join("\n");
+}

--- a/packages/cli/lib/endscreen.js
+++ b/packages/cli/lib/endscreen.js
@@ -1,0 +1,172 @@
+/**
+ * The end screen: session summary plus the three questions —
+ *   1. Loop more?                        (reset the miss counter, continue)
+ *   2. Submit stats to the Site leaderboard?   (URL + favicon are public)
+ *   3. Submit anonymous improvements data?     (categories + deltas only)
+ */
+
+import { writeFileSync } from "node:fs";
+import {
+  buildImprovementsPayload,
+  buildSitePayloads,
+  submitImprovements,
+  submitSite,
+} from "./apiClient.js";
+import { confirm, question } from "./picker.js";
+import { ARROW, FAIL, OK, bold, cyan, dim, formatMs, formatPct, green, hr, red, yellow } from "./ui.js";
+
+function pctChangeLabel(baseline, final) {
+  if (!(baseline > 0) || typeof final !== "number") return "";
+  const pct = ((final - baseline) / baseline) * 100;
+  const label = formatPct(pct);
+  return pct <= 0 ? green(label) : red(label);
+}
+
+function metricLine(name, baseline, final) {
+  if (typeof baseline !== "number" || typeof final !== "number") return null;
+  const change = pctChangeLabel(baseline, final);
+  return `    ${name.padEnd(5)} ${String(Math.round(baseline)).padStart(6)}ms ${ARROW} ${String(Math.round(final)).padStart(6)}ms  ${change}`;
+}
+
+export function renderSummary(results, state) {
+  const lines = ["", hr(), `  ${bold("makefaster — session summary")} ${dim(`(round ${state.round})`)}`, hr()];
+
+  if (!results || results.parseError) {
+    lines.push(
+      "",
+      yellow("  No readable .makefaster/results.json was produced this round."),
+      dim("  (The agent may have been interrupted before profiling finished.)"),
+      "",
+    );
+    return lines.join("\n");
+  }
+
+  const site = results.site?.url ? ` — ${cyan(results.site.url)}` : "";
+  lines.push(`  north star: ${bold(results.northStar || "lcp")}${site}  ${dim(results.profilingTool ? `via ${results.profilingTool}` : "")}`);
+
+  for (const mode of ["cold", "warm"]) {
+    const baseline = results.baseline?.[mode];
+    const final = results.final?.[mode];
+    if (!baseline || !final) continue;
+    lines.push("", `  ${bold(mode)} load`);
+    for (const [label, key] of [["LCP", "lcpMs"], ["TTI", "ttiMs"], ["FCP", "fcpMs"], ["TBT", "tbtMs"]]) {
+      const line = metricLine(label, baseline[key], final[key]);
+      if (line) lines.push(line);
+    }
+  }
+
+  const iterations = results.iterations || [];
+  const kept = iterations.filter((it) => it.kept === true);
+  lines.push("", `  iterations: ${iterations.length}  kept: ${kept.length}  miss streak at exit: ${results.missStreak ?? "?"}`);
+  if (kept.length > 0) {
+    lines.push("", `  ${bold("kept improvements")}`);
+    for (const it of kept) {
+      const delta = [
+        typeof it.deltaMs === "number" ? formatMs(it.deltaMs) : null,
+        typeof it.deltaPct === "number" ? formatPct(it.deltaPct) : null,
+      ].filter(Boolean).join(" / ");
+      lines.push(`    ${OK} ${it.name}  ${green(delta)}`);
+      if (it.description) lines.push(`      ${dim(it.description)}`);
+    }
+  }
+  const reverted = iterations.filter((it) => it.kept !== true);
+  if (reverted.length > 0) {
+    lines.push("", dim(`  reverted: ${reverted.map((it) => it.name).join(", ")}`.slice(0, 200)));
+  }
+  lines.push(hr(), "");
+  return lines.join("\n");
+}
+
+function savePending(paths, entry) {
+  try {
+    writeFileSync(paths.pending, JSON.stringify(entry, null, 2) + "\n");
+    console.log(dim(`  payload saved to ${paths.pending} — resubmit later with the same POST.`));
+  } catch {
+    /* the payload was already printed in the error path; nothing else to do */
+  }
+}
+
+async function askSiteSubmission({ results, state, paths }) {
+  let siteUrl = state.siteUrl || results?.site?.url || null;
+  const payloadsPreview = buildSitePayloads(results || {}, siteUrl || "example.com");
+  if (payloadsPreview.length === 0) {
+    console.log(dim("  Site leaderboard: skipped — results.json has no complete cold/warm baseline+final numbers."));
+    return;
+  }
+
+  console.log(`  ${bold("2. Submit stats to the Site leaderboard?")}`);
+  console.log(dim("     Your site's URL and favicon will be displayed publicly, with its"));
+  console.log(dim("     measured LCP/TTI and the improvement since baseline."));
+  const wants = await confirm("     Submit site stats?", { def: false });
+  if (!wants) return;
+
+  if (!siteUrl) {
+    siteUrl = await question("     Site URL (e.g. example.com): ");
+  }
+  if (!siteUrl) {
+    console.log(yellow("     No URL given — skipping the site submission."));
+    return;
+  }
+
+  const payloads = buildSitePayloads(results, siteUrl);
+  for (const payload of payloads) {
+    try {
+      const res = await submitSite(state.apiBase, payload);
+      console.log(`     ${OK} ${payload.mode}: ${res.created ? "added to" : "updated on"} the board (${payload.url}, LCP ${formatPct(payload.lcpDelta)})`);
+    } catch (err) {
+      console.log(`     ${FAIL} ${payload.mode}: ${red(err.message)}`);
+      savePending(paths, { endpoint: "/api/submit-site", apiBase: state.apiBase, payload });
+    }
+  }
+}
+
+async function askImprovementsSubmission({ results, state, paths }) {
+  const payload = buildImprovementsPayload(results || {});
+  if (!payload) {
+    console.log(dim("  Improvements data: skipped — no kept improvements with measured deltas."));
+    return;
+  }
+
+  console.log(`  ${bold("3. Submit anonymous improvements data?")}`);
+  console.log(dim(`     No URL, no site identity — only what worked (${payload.improvements.length} ` +
+    `improvement${payload.improvements.length === 1 ? "" : "s"}: name, description, deltas). This`));
+  console.log(dim("     grows the public improvement leaderboard every site learns from."));
+  const wants = await confirm("     Submit anonymous improvements?", { def: false });
+  if (!wants) return;
+
+  try {
+    const res = await submitImprovements(state.apiBase, payload);
+    for (const result of res.results || []) {
+      const verb = result.action === "created" ? cyan("new category") : `matched ${dim(`(${result.similarity})`)}`;
+      console.log(`     ${OK} ${result.input} ${ARROW} ${bold(result.category)} — ${verb}`);
+    }
+  } catch (err) {
+    console.log(`     ${FAIL} ${red(err.message)}`);
+    savePending(paths, { endpoint: "/api/submit-improvements", apiBase: state.apiBase, payload });
+  }
+}
+
+/**
+ * @returns {Promise<{loopMore: boolean}>}
+ */
+export async function runEndScreen({ results, state, paths }) {
+  console.log(renderSummary(results, state));
+
+  console.log(`  ${bold("1. Loop more?")}`);
+  console.log(dim(`     Resets the miss counter (currently ${results?.missStreak ?? "?"}/${state.maxMisses}) and continues the loop.`));
+  const loopMore = await confirm("     Keep looping?", { def: false });
+  console.log("");
+
+  if (loopMore) {
+    // Questions 2 & 3 come around again after the next round's end screen.
+    return { loopMore: true };
+  }
+
+  await askSiteSubmission({ results, state, paths });
+  console.log("");
+  await askImprovementsSubmission({ results, state, paths });
+  console.log("");
+  console.log(dim(`  Leaderboards: ${state.apiBase}/site-leaderboard.html - ${state.apiBase}/improvement-leaderboard.html`));
+  console.log("");
+  return { loopMore: false };
+}

--- a/packages/cli/lib/endscreen.js
+++ b/packages/cli/lib/endscreen.js
@@ -152,6 +152,14 @@ async function askImprovementsSubmission({ results, state, paths }) {
 export async function runEndScreen({ results, state, paths }) {
   console.log(renderSummary(results, state));
 
+  if (!process.stdin.isTTY) {
+    console.log(dim("  stdin is not a TTY — skipping the end-screen questions (loop more /"));
+    console.log(dim("  submit site stats / submit anonymous improvements). Run makefaster in"));
+    console.log(dim("  a terminal to submit, or POST .makefaster/results.json-derived payloads"));
+    console.log(dim(`  to ${state.apiBase}/api/submit-site and /api/submit-improvements.`));
+    return { loopMore: false };
+  }
+
   console.log(`  ${bold("1. Loop more?")}`);
   console.log(dim(`     Resets the miss counter (currently ${results?.missStreak ?? "?"}/${state.maxMisses}) and continues the loop.`));
   const loopMore = await confirm("     Keep looping?", { def: false });

--- a/packages/cli/lib/improvements.js
+++ b/packages/cli/lib/improvements.js
@@ -1,0 +1,92 @@
+/**
+ * Import the site's top-50 improvement categories — the checklist of likely
+ * wins the loop consults. Sources, in order of freshness:
+ *
+ *   1. an explicit --improvements <path|url> override,
+ *   2. the live leaderboard:   <apiBase>/data/improvements.json
+ *   3. the repo on GitHub:     https://raw.githubusercontent.com/jjcm/makefaster/main/data/improvements.json
+ *   4. the target repo itself: <cwd>/data/improvements.json (when present)
+ *   5. the copy packaged with this CLI (offline fallback).
+ *
+ * The checklist is a guide of what has worked across sites — the skill is
+ * told explicitly that it is NOT a script to apply blindly.
+ */
+
+import { readFileSync } from "node:fs";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const RAW_GITHUB_URL = "https://raw.githubusercontent.com/jjcm/makefaster/main/data/improvements.json";
+const FETCH_TIMEOUT_MS = 6_000;
+const TOP_N = 50;
+
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+
+async function fetchJson(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { headers: { accept: "application/json" }, signal: controller.signal });
+    if (!res.ok) throw new Error(`GET ${url} responded ${res.status}`);
+    return await res.json();
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function readJsonFile(path) {
+  return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function isValidChecklist(data) {
+  return Array.isArray(data) && data.length > 0 && data.every((row) => row && typeof row.name === "string");
+}
+
+function topFifty(categories) {
+  return [...categories]
+    .sort((a, b) => (a.rank ?? Number.MAX_SAFE_INTEGER) - (b.rank ?? Number.MAX_SAFE_INTEGER))
+    .slice(0, TOP_N)
+    .map(({ name, description, count, avgImprovementMs, avgImprovementPct, rank }) => ({
+      rank, name, description, count, avgImprovementMs, avgImprovementPct,
+    }));
+}
+
+/**
+ * @param {object} args
+ * @param {string|null} args.override --improvements value (path or URL)
+ * @param {string} args.apiBase
+ * @param {string} args.cwd target repo
+ * @param {string} [args.rawUrl] GitHub-raw fallback (injectable for tests)
+ * @returns {Promise<{categories: Array<object>, source: string}>}
+ */
+export async function importChecklist({ override, apiBase, cwd, rawUrl = RAW_GITHUB_URL }) {
+  const attempts = [];
+
+  if (override) {
+    if (/^https?:\/\//i.test(override)) {
+      attempts.push({ source: override, load: () => fetchJson(override) });
+    } else {
+      const path = isAbsolute(override) ? override : resolve(cwd, override);
+      attempts.push({ source: path, load: () => readJsonFile(path) });
+    }
+  } else {
+    if (apiBase) {
+      attempts.push({ source: `${apiBase}/data/improvements.json`, load: () => fetchJson(`${apiBase}/data/improvements.json`) });
+    }
+    attempts.push({ source: rawUrl, load: () => fetchJson(rawUrl) });
+    attempts.push({ source: join(cwd, "data", "improvements.json"), load: () => readJsonFile(join(cwd, "data", "improvements.json")) });
+    attempts.push({ source: "packaged fallback", load: () => readJsonFile(join(PACKAGE_ROOT, "data", "improvements.json")) });
+  }
+
+  const failures = [];
+  for (const attempt of attempts) {
+    try {
+      const data = await attempt.load();
+      if (!isValidChecklist(data)) throw new Error("not a category list");
+      return { categories: topFifty(data), source: attempt.source };
+    } catch (err) {
+      failures.push(`${attempt.source}: ${err.message}`);
+    }
+  }
+  throw new Error(`could not import the improvement checklist from any source:\n  ${failures.join("\n  ")}`);
+}

--- a/packages/cli/lib/picker.js
+++ b/packages/cli/lib/picker.js
@@ -1,0 +1,99 @@
+/**
+ * Interactive terminal prompts over raw readline — no dependencies.
+ *   selectFrom  — arrow-key (or j/k, or 1-9) list picker
+ *   confirm     — y/n question
+ *   question    — free-text question
+ * Non-TTY stdin throws { code: "NO_TTY" } so callers can degrade explicitly.
+ */
+
+import readline from "node:readline";
+import { bold, cyan, dim } from "./ui.js";
+
+function requireTty() {
+  if (!process.stdin.isTTY) {
+    throw Object.assign(new Error("interactive prompt needs a TTY"), { code: "NO_TTY" });
+  }
+}
+
+/**
+ * @param {object} args
+ * @param {string} args.title
+ * @param {Array<{label: string, detail?: string}>} args.options
+ * @param {number} [args.defaultIndex]
+ * @returns {Promise<number|null>} selected index, or null when cancelled
+ */
+export function selectFrom({ title, options, defaultIndex = 0 }) {
+  requireTty();
+  return new Promise((resolve) => {
+    const stdin = process.stdin;
+    const stdout = process.stdout;
+    let index = Math.min(Math.max(defaultIndex, 0), options.length - 1);
+    let renderedLines = 0;
+
+    function render() {
+      if (renderedLines > 0) {
+        stdout.write(`\u001b[${renderedLines}A\u001b[J`);
+      }
+      const lines = [title, ...options.map((option, i) => {
+        const pointer = i === index ? cyan(">") : " ";
+        const label = i === index ? bold(option.label) : option.label;
+        const detail = option.detail ? `  ${dim(option.detail)}` : "";
+        return `  ${pointer} ${i + 1}. ${label}${detail}`;
+      }), dim("  arrows/jk move - enter select - q cancel")];
+      stdout.write(lines.join("\n") + "\n");
+      renderedLines = lines.length;
+    }
+
+    function finish(result) {
+      stdin.setRawMode(false);
+      stdin.pause();
+      stdin.removeListener("data", onData);
+      resolve(result);
+    }
+
+    function onData(chunk) {
+      const key = chunk.toString("utf8");
+      if (key === "\u0003" || key === "q" || key === "\u001b") return finish(null); // ctrl-c / q / esc
+      if (key === "\r" || key === "\n") return finish(index);
+      if (key === "\u001b[A" || key === "k") index = (index - 1 + options.length) % options.length;
+      else if (key === "\u001b[B" || key === "j") index = (index + 1) % options.length;
+      else if (/^[1-9]$/.test(key)) {
+        const n = Number.parseInt(key, 10) - 1;
+        if (n < options.length) { index = n; render(); return finish(index); }
+      }
+      render();
+    }
+
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.on("data", onData);
+    render();
+  });
+}
+
+/** y/n question; returns the default on empty input. */
+export function confirm(prompt, { def = false } = {}) {
+  requireTty();
+  const suffix = def ? "[Y/n]" : "[y/N]";
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(`${prompt} ${dim(suffix)} `, (answer) => {
+      rl.close();
+      const a = answer.trim().toLowerCase();
+      if (a === "") return resolve(def);
+      resolve(a === "y" || a === "yes");
+    });
+  });
+}
+
+/** Free-text question; returns the trimmed answer ("" when empty). */
+export function question(prompt) {
+  requireTty();
+  return new Promise((resolve) => {
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}

--- a/packages/cli/lib/session.js
+++ b/packages/cli/lib/session.js
@@ -1,0 +1,128 @@
+/**
+ * Session plumbing: the .makefaster/ working directory the CLI shares with
+ * the agent, the kickoff/continue prompts, and the interactive agent spawn.
+ */
+
+import { spawnSync } from "node:child_process";
+import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const SKILL_SOURCE = join(PACKAGE_ROOT, "packages", "skill", "SKILL.md");
+
+export const SESSION_DIR_NAME = ".makefaster";
+
+export function sessionPaths(cwd) {
+  const dir = join(cwd, SESSION_DIR_NAME);
+  return {
+    dir,
+    skill: join(dir, "SKILL.md"),
+    improvements: join(dir, "improvements.json"),
+    state: join(dir, "state.json"),
+    results: join(dir, "results.json"),
+    pending: join(dir, "pending-submissions.json"),
+  };
+}
+
+/**
+ * Keep the session dir out of `git status` without touching the repo's own
+ * .gitignore: .git/info/exclude is local-only.
+ */
+function excludeFromGit(cwd) {
+  const excludePath = join(cwd, ".git", "info", "exclude");
+  if (!existsSync(join(cwd, ".git"))) return;
+  try {
+    const current = existsSync(excludePath) ? readFileSync(excludePath, "utf8") : "";
+    if (!current.split(/\r?\n/).includes(`${SESSION_DIR_NAME}/`)) {
+      mkdirSync(dirname(excludePath), { recursive: true });
+      appendFileSync(excludePath, `${current.endsWith("\n") || current === "" ? "" : "\n"}${SESSION_DIR_NAME}/\n`);
+    }
+  } catch {
+    // Cosmetic only — the skill also tells the agent never to commit .makefaster/.
+  }
+}
+
+export function prepareSession({ cwd, provider, checklist, checklistSource, apiBase, maxMisses, siteUrl }) {
+  const paths = sessionPaths(cwd);
+  mkdirSync(paths.dir, { recursive: true });
+  copyFileSync(SKILL_SOURCE, paths.skill);
+  writeFileSync(paths.improvements, JSON.stringify({ source: checklistSource, categories: checklist }, null, 2) + "\n");
+
+  const state = {
+    version: 1,
+    provider: provider.key,
+    startedAt: new Date().toISOString(),
+    apiBase,
+    siteUrl: siteUrl || null,
+    maxMisses,
+    missStreak: 0,
+    round: 1,
+  };
+  writeFileSync(paths.state, JSON.stringify(state, null, 2) + "\n");
+  excludeFromGit(cwd);
+  return { paths, state };
+}
+
+export function readState(cwd) {
+  const paths = sessionPaths(cwd);
+  try {
+    return JSON.parse(readFileSync(paths.state, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+export function writeState(cwd, state) {
+  writeFileSync(sessionPaths(cwd).state, JSON.stringify(state, null, 2) + "\n");
+}
+
+export function readResults(cwd) {
+  const paths = sessionPaths(cwd);
+  if (!existsSync(paths.results)) return null;
+  try {
+    return JSON.parse(readFileSync(paths.results, "utf8"));
+  } catch {
+    return { parseError: true };
+  }
+}
+
+export function kickoffPrompt() {
+  return [
+    "Read .makefaster/SKILL.md and follow it exactly. It defines the makefaster",
+    "performance loop for the site in this repo: profile a user-felt metric,",
+    "form ONE hypothesis per iteration, measure, keep it only if it beats the",
+    "noise floor, otherwise revert. The checklist of likely wins is",
+    ".makefaster/improvements.json (a guide, not a script). Loop limits live in",
+    ".makefaster/state.json — stop when missStreak reaches maxMisses. Keep",
+    ".makefaster/results.json valid and up to date after every iteration",
+    "(schema is in the skill); the CLI reads it when you exit.",
+  ].join(" ");
+}
+
+export function continuePrompt() {
+  return [
+    "Continue the makefaster performance loop in this repo. The user chose to",
+    "loop more, so the miss counter in .makefaster/state.json was reset. Re-read",
+    ".makefaster/SKILL.md for the rules and .makefaster/results.json for what",
+    "was already tried (do not repeat reverted experiments without a new reason).",
+    "Same discipline: one hypothesis per iteration, measure, keep or revert,",
+    "update results.json every iteration, stop when missStreak reaches maxMisses.",
+  ].join(" ");
+}
+
+/**
+ * Hand the terminal to the chosen agent CLI. All three providers accept an
+ * initial prompt as a positional argument and then run interactively, so the
+ * user can watch and steer the loop.
+ */
+export function runAgent({ provider, prompt, cwd }) {
+  const result = spawnSync(provider.executablePath, [prompt], {
+    cwd,
+    stdio: "inherit",
+  });
+  if (result.error) {
+    throw new Error(`failed to launch ${provider.displayName} (${provider.executablePath}): ${result.error.message}`);
+  }
+  return { exitCode: result.status ?? 0 };
+}

--- a/packages/cli/lib/ui.js
+++ b/packages/cli/lib/ui.js
@@ -1,0 +1,55 @@
+/**
+ * Tiny terminal helpers — colors that respect NO_COLOR and non-TTY output,
+ * plus the shared banner. No dependencies.
+ */
+
+const useColor =
+  !process.env.NO_COLOR &&
+  process.env.TERM !== "dumb" &&
+  Boolean(process.stdout.isTTY);
+
+function paint(code) {
+  return (text) => (useColor ? `\u001b[${code}m${text}\u001b[0m` : String(text));
+}
+
+export const bold = paint("1");
+export const dim = paint("2");
+export const red = paint("31");
+export const green = paint("32");
+export const yellow = paint("33");
+export const cyan = paint("36");
+
+export const OK = green("+");
+export const FAIL = red("x");
+export const ARROW = "->";
+
+export function hr(width = 56) {
+  return dim("-".repeat(width));
+}
+
+export function banner(version) {
+  const lines = [
+    "",
+    `  ${bold("makefaster")} ${dim(`v${version}`)}`,
+    `  ${dim("autoresearch loop: profile -> hypothesis -> measure -> keep or revert")}`,
+    "",
+  ];
+  return lines.join("\n");
+}
+
+/** "1842" -> "1,842" without locale surprises. */
+export function formatInt(value) {
+  return Math.round(value).toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+}
+
+/** Signed percentage with one decimal: -12.34 -> "-12.3%". */
+export function formatPct(value) {
+  const rounded = Math.round(value * 10) / 10;
+  return `${rounded > 0 ? "+" : ""}${rounded}%`;
+}
+
+/** Signed milliseconds: -120 -> "-120ms". */
+export function formatMs(value) {
+  const rounded = Math.round(value);
+  return `${rounded > 0 ? "+" : ""}${formatInt(rounded)}ms`;
+}

--- a/packages/cli/test/apiclient.test.mjs
+++ b/packages/cli/test/apiclient.test.mjs
@@ -1,0 +1,86 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_API_BASE,
+  buildImprovementsPayload,
+  buildSitePayloads,
+  resolveApiBase,
+} from "../lib/apiClient.js";
+
+const RESULTS = {
+  version: 1,
+  site: { url: "example.com", name: "Example", favicon: "https://example.com/favicon.ico" },
+  northStar: "lcp",
+  baseline: {
+    cold: { lcpMs: 2400, ttiMs: 3900, fcpMs: 1400 },
+    warm: { lcpMs: 1100, ttiMs: 1700 },
+  },
+  final: {
+    cold: { lcpMs: 1750, ttiMs: 3050, fcpMs: 1150 },
+    warm: { lcpMs: 780, ttiMs: 1240 },
+  },
+  iterations: [
+    { n: 1, name: "Inline critical CSS", description: "Inlined above-the-fold styles", category: "Inline Critical CSS", deltaMs: -260, deltaPct: -10.8, kept: true },
+    { n: 2, name: "Preload thumbnails", description: "Preload first grid images", category: "Resource Preloading", deltaMs: 150, deltaPct: 6.2, kept: false },
+    { n: 3, name: "Subset fonts", description: "Only ship used glyphs", category: "Font Subsetting", deltaMs: -90, deltaPct: -4.1, kept: true },
+    { n: 4, name: "No-delta oddity", description: "kept but no numbers", kept: true },
+  ],
+  missStreak: 5,
+  stoppedReason: "miss-streak",
+};
+
+test("resolveApiBase: flag > env > default, trailing slash stripped", () => {
+  assert.equal(resolveApiBase({ flag: "https://x.dev/", env: { MAKEFASTER_API_BASE: "https://y.dev" } }), "https://x.dev");
+  assert.equal(resolveApiBase({ env: { MAKEFASTER_API_BASE: "https://y.dev/" } }), "https://y.dev");
+  assert.equal(resolveApiBase({ env: {} }), DEFAULT_API_BASE);
+});
+
+test("buildSitePayloads produces one payload per complete mode with computed deltas", () => {
+  const payloads = buildSitePayloads(RESULTS, "example.com");
+  assert.equal(payloads.length, 2);
+  const cold = payloads.find((p) => p.mode === "cold");
+  assert.deepEqual(cold, {
+    url: "example.com",
+    mode: "cold",
+    lcpRaw: 1750,
+    lcpDelta: -27.1, // (1750-2400)/2400
+    ttiRaw: 3050,
+    ttiDelta: -21.8,
+    name: "Example",
+    favicon: "https://example.com/favicon.ico",
+  });
+  const warm = payloads.find((p) => p.mode === "warm");
+  assert.equal(warm.lcpDelta, -29.1);
+});
+
+test("buildSitePayloads skips incomplete modes and zero baselines", () => {
+  const onlyCold = buildSitePayloads({
+    baseline: { cold: { lcpMs: 1000, ttiMs: 2000 }, warm: { lcpMs: 500 } },
+    final: { cold: { lcpMs: 900, ttiMs: 1800 }, warm: { lcpMs: 400, ttiMs: 800 } },
+  }, "example.com");
+  assert.equal(onlyCold.length, 1);
+  assert.equal(onlyCold[0].mode, "cold");
+
+  const zeroBase = buildSitePayloads({
+    baseline: { cold: { lcpMs: 0, ttiMs: 2000 } },
+    final: { cold: { lcpMs: 900, ttiMs: 1800 } },
+  }, "example.com");
+  assert.equal(zeroBase.length, 0);
+
+  assert.equal(buildSitePayloads(null, "example.com").length, 0);
+});
+
+test("buildImprovementsPayload keeps only kept iterations with deltas, anonymously", () => {
+  const payload = buildImprovementsPayload(RESULTS);
+  assert.equal(payload.improvements.length, 2); // kept:false and no-delta entries dropped
+  assert.deepEqual(payload.improvements[0], {
+    name: "Inline critical CSS",
+    description: "Inlined above-the-fold styles",
+    deltaMs: -260,
+    deltaPct: -10.8,
+  });
+  assert.equal(JSON.stringify(payload).includes("example.com"), false, "payload must not leak the site URL");
+
+  assert.equal(buildImprovementsPayload({ iterations: [] }), null);
+  assert.equal(buildImprovementsPayload({}), null);
+});

--- a/packages/cli/test/args.test.mjs
+++ b/packages/cli/test/args.test.mjs
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseArgs, USAGE } from "../lib/args.js";
+
+test("defaults", () => {
+  const { args, errors } = parseArgs([]);
+  assert.deepEqual(errors, []);
+  assert.equal(args.targetDir, null);
+  assert.equal(args.cli, null);
+  assert.equal(args.maxMisses, 5);
+  assert.equal(args.help, false);
+});
+
+test("positional dir plus flags", () => {
+  const { args, errors } = parseArgs(["../mysite", "--cli", "claude", "--url", "example.com", "--max-misses", "3", "--api", "https://api.example.com/"]);
+  assert.deepEqual(errors, []);
+  assert.equal(args.targetDir, "../mysite");
+  assert.equal(args.cli, "claude");
+  assert.equal(args.url, "example.com");
+  assert.equal(args.maxMisses, 3);
+  assert.equal(args.api, "https://api.example.com"); // trailing slash stripped
+});
+
+test("--cli aliases map to canonical keys", () => {
+  for (const [alias, key] of [["cursor-agent", "cursor"], ["agent", "cursor"], ["claude-code", "claude"], ["Codex", "codex"]]) {
+    const { args, errors } = parseArgs(["--cli", alias]);
+    assert.deepEqual(errors, [], alias);
+    assert.equal(args.cli, key, alias);
+  }
+});
+
+test("errors: unknown flag, bad cli, bad max-misses, missing values, extra positional", () => {
+  assert.match(parseArgs(["--frobnicate"]).errors[0], /unknown option/);
+  assert.match(parseArgs(["--cli", "gemini"]).errors[0], /--cli must be one of/);
+  assert.match(parseArgs(["--max-misses", "0"]).errors[0], /between 1 and 100/);
+  assert.match(parseArgs(["--max-misses", "nope"]).errors[0], /between 1 and 100/);
+  assert.match(parseArgs(["--url"]).errors[0], /needs a value/);
+  assert.match(parseArgs(["a", "b"]).errors[0], /unexpected argument/);
+});
+
+test("help and version flags", () => {
+  assert.equal(parseArgs(["-h"]).args.help, true);
+  assert.equal(parseArgs(["--version"]).args.version, true);
+  assert.match(USAGE, /npx makefaster/);
+  assert.match(USAGE, /--max-misses/);
+});

--- a/packages/cli/test/detect.test.mjs
+++ b/packages/cli/test/detect.test.mjs
@@ -1,0 +1,190 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectProviders, missingCliGuidance } from "../lib/detect.js";
+
+function makeSandbox() {
+  const root = mkdtempSync(join(tmpdir(), "mf-detect-"));
+  const bin = join(root, "bin");
+  const home = join(root, "home");
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(home, { recursive: true });
+  return { root, bin, home };
+}
+
+function fakeBinary(dir, name) {
+  const path = join(dir, name);
+  writeFileSync(path, "#!/bin/sh\necho fake\n");
+  chmodSync(path, 0o755);
+  return path;
+}
+
+const quietProbe = () => ({ ok: true, version: "9.9.9 (test)", output: "9.9.9 (test)" });
+
+function detect({ env = {}, home, isRoot = false, probeVersion = quietProbe } = {}) {
+  return detectProviders({
+    env: { PATH: "", ...env },
+    platform: "linux",
+    home,
+    isRoot,
+    execDir: null,
+    probeVersion,
+  });
+}
+
+test("finds all three providers on PATH", () => {
+  const { root, bin, home } = makeSandbox();
+  try {
+    fakeBinary(bin, "cursor-agent");
+    fakeBinary(bin, "claude");
+    fakeBinary(bin, "codex");
+    const reports = detect({ env: { PATH: bin }, home });
+    for (const report of reports) {
+      assert.equal(report.found, true, `${report.key} should be found`);
+      assert.equal(report.source, "path");
+      assert.equal(report.version, "9.9.9 (test)");
+    }
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("falls back to well-known install locations", () => {
+  const { root, home } = makeSandbox();
+  try {
+    mkdirSync(join(home, ".local", "bin"), { recursive: true });
+    mkdirSync(join(home, ".claude", "local"), { recursive: true });
+    mkdirSync(join(home, ".cursor", "bin"), { recursive: true });
+    fakeBinary(join(home, ".claude", "local"), "claude");
+    fakeBinary(join(home, ".cursor", "bin"), "cursor-agent");
+    const reports = detect({ home });
+    const claude = reports.find((r) => r.key === "claude");
+    const cursor = reports.find((r) => r.key === "cursor");
+    const codex = reports.find((r) => r.key === "codex");
+    assert.equal(claude.found, true);
+    assert.equal(claude.source, "well-known");
+    assert.equal(claude.executablePath, join(home, ".claude", "local", "claude"));
+    assert.equal(cursor.found, true);
+    assert.equal(cursor.source, "well-known");
+    assert.equal(codex.found, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("well-known locations are skipped when running as root", () => {
+  const { root, home } = makeSandbox();
+  try {
+    mkdirSync(join(home, ".local", "bin"), { recursive: true });
+    fakeBinary(join(home, ".local", "bin"), "claude");
+    const reports = detect({ home, isRoot: true });
+    assert.equal(reports.find((r) => r.key === "claude").found, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("env override wins and BB_CLAUDE_CODE_EXECUTABLE is honored", () => {
+  const { root, bin, home } = makeSandbox();
+  try {
+    const claudePath = fakeBinary(bin, "my-claude");
+    const reports = detect({ env: { BB_CLAUDE_CODE_EXECUTABLE: claudePath }, home });
+    const claude = reports.find((r) => r.key === "claude");
+    assert.equal(claude.found, true);
+    assert.equal(claude.source, "env:BB_CLAUDE_CODE_EXECUTABLE");
+    assert.equal(claude.executablePath, claudePath);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a broken env override is a visible error, not a silent fall-through", () => {
+  const { root, bin, home } = makeSandbox();
+  try {
+    fakeBinary(bin, "claude"); // valid binary on PATH that must NOT be used
+    const reports = detect({
+      env: { PATH: bin, CLAUDE_CODE_EXECUTABLE: join(root, "does-not-exist") },
+      home,
+    });
+    const claude = reports.find((r) => r.key === "claude");
+    assert.equal(claude.found, false);
+    assert.match(claude.error, /CLAUDE_CODE_EXECUTABLE/);
+    assert.match(claude.error, /does-not-exist/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a bare `agent` binary is only accepted when it is Cursor's", () => {
+  const { root, bin, home } = makeSandbox();
+  try {
+    fakeBinary(bin, "agent"); // some unrelated agent
+    let reports = detect({
+      env: { PATH: bin },
+      home,
+      probeVersion: () => ({ ok: true, version: "0.1", output: "generic agent 0.1" }),
+    });
+    assert.equal(reports.find((r) => r.key === "cursor").found, false, "unrelated `agent` must be rejected");
+
+    // Same binary, but --version identifies it as Cursor's agent.
+    reports = detect({
+      env: { PATH: bin },
+      home,
+      probeVersion: () => ({ ok: true, version: "2026.1", output: "cursor-agent 2026.1" }),
+    });
+    assert.equal(reports.find((r) => r.key === "cursor").found, true, "`agent` reporting cursor must be accepted");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a symlinked `agent` resolving into a cursor install is accepted without probing", () => {
+  const { root, bin, home } = makeSandbox();
+  try {
+    const versions = join(home, ".local", "share", "cursor-agent", "versions", "1.0");
+    mkdirSync(versions, { recursive: true });
+    const real = fakeBinary(versions, "cursor-agent");
+    symlinkSync(real, join(bin, "agent"));
+    const reports = detect({
+      env: { PATH: bin },
+      home,
+      probeVersion: (path) => (path.endsWith("agent") ? { ok: true, version: "1.0", output: "1.0" } : quietProbe()),
+    });
+    const cursor = reports.find((r) => r.key === "cursor");
+    assert.equal(cursor.found, true);
+    assert.equal(cursor.source, "path");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("config-home hints surface when the binary is missing", () => {
+  const { root, home } = makeSandbox();
+  try {
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    const reports = detect({ home });
+    const codex = reports.find((r) => r.key === "codex");
+    assert.equal(codex.found, false);
+    assert.match(codex.hint, /\.codex/);
+    assert.match(codex.hint, /no runnable binary/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("missingCliGuidance names every installer and does not offer a bundled model", () => {
+  const { root, home } = makeSandbox();
+  try {
+    const reports = detect({ home });
+    const guidance = missingCliGuidance(reports);
+    assert.match(guidance, /does not bundle or download a model/);
+    assert.match(guidance, /cursor\.com\/install/);
+    assert.match(guidance, /claude\.ai\/install\.sh/);
+    assert.match(guidance, /npm install -g @openai\/codex/);
+    assert.match(guidance, /CLAUDE_CODE_EXECUTABLE/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/packages/cli/test/improvements.test.mjs
+++ b/packages/cli/test/improvements.test.mjs
@@ -1,0 +1,92 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { importChecklist } from "../lib/improvements.js";
+
+const SAMPLE = [
+  { rank: 2, name: "Tree Shaking", description: "Remove unused JavaScript", count: 10, avgImprovementMs: -300, avgImprovementPct: -20 },
+  { rank: 1, name: "Gzip", description: "Enable compression", count: 20, avgImprovementMs: -400, avgImprovementPct: -25 },
+];
+
+function listen(handler) {
+  const server = createServer(handler);
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve({ server, base: `http://127.0.0.1:${server.address().port}` }));
+  });
+}
+
+test("imports from the live API base and sorts by rank", async () => {
+  const { server, base } = await listen((req, res) => {
+    assert.equal(req.url, "/data/improvements.json");
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify(SAMPLE));
+  });
+  try {
+    const { categories, source } = await importChecklist({ override: null, apiBase: base, cwd: tmpdir() });
+    assert.equal(source, `${base}/data/improvements.json`);
+    assert.deepEqual(categories.map((c) => c.name), ["Gzip", "Tree Shaking"]);
+  } finally {
+    server.close();
+  }
+});
+
+test("an --improvements file override wins", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "mf-imp-"));
+  try {
+    const file = join(dir, "custom.json");
+    writeFileSync(file, JSON.stringify(SAMPLE));
+    const { categories, source } = await importChecklist({ override: file, apiBase: "http://127.0.0.1:1", cwd: dir });
+    assert.equal(source, file);
+    assert.equal(categories.length, 2);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("falls back to the target repo's data/improvements.json when remotes are down", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "mf-imp-"));
+  try {
+    mkdirSync(join(dir, "data"), { recursive: true });
+    writeFileSync(join(dir, "data", "improvements.json"), JSON.stringify(SAMPLE));
+    // Both remote sources point at a closed port; the local repo file wins.
+    const { categories, source } = await importChecklist({
+      override: null, apiBase: "http://127.0.0.1:1", cwd: dir, rawUrl: "http://127.0.0.1:1/raw.json",
+    });
+    assert.equal(source, join(dir, "data", "improvements.json"));
+    assert.equal(categories.length, 2);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("caps the checklist at the top 50 by rank", async () => {
+  const big = Array.from({ length: 80 }, (_, i) => ({ rank: 80 - i, name: `Cat ${80 - i}` }));
+  const dir = mkdtempSync(join(tmpdir(), "mf-imp-"));
+  try {
+    const file = join(dir, "big.json");
+    writeFileSync(file, JSON.stringify(big));
+    const { categories } = await importChecklist({ override: file, apiBase: null, cwd: dir });
+    assert.equal(categories.length, 50);
+    assert.equal(categories[0].name, "Cat 1");
+    assert.equal(categories[49].name, "Cat 50");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("rejects invalid checklist data with a useful error", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "mf-imp-"));
+  try {
+    const file = join(dir, "bad.json");
+    writeFileSync(file, JSON.stringify({ nope: true }));
+    await assert.rejects(
+      importChecklist({ override: file, apiBase: null, cwd: dir }),
+      /could not import the improvement checklist/,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/skill/SKILL.md
+++ b/packages/skill/SKILL.md
@@ -1,0 +1,193 @@
+---
+name: makefaster
+description: Autoresearch loop that makes the site in this repo measurably faster. Profile a user-felt metric, change one hypothesis per iteration, keep or revert with numbers, stop after too many straight misses, and report results for the public leaderboards. Driven by `npx makefaster`.
+---
+
+# The makefaster loop
+
+You are running inside a makefaster session: the `makefaster` CLI detected the
+agent CLI you are, asked the user to pick you, and handed you this repo. Your
+job is to make the site in the current directory measurably faster for real
+users, one disciplined experiment at a time. The discipline is the same as
+jjcm/speedupskill: **measure a user-felt metric first, change one hypothesis
+per iteration, keep or revert with numbers.**
+
+## The session contract (files in `.makefaster/`)
+
+The CLI owns this directory. Never commit it (it is already in
+`.git/info/exclude`).
+
+| file | who writes it | what it is |
+|---|---|---|
+| `SKILL.md` | CLI | this file |
+| `improvements.json` | CLI | the imported top-50 improvement categories — your checklist |
+| `state.json` | CLI creates, **you update `missStreak`** | loop limits and counters |
+| `results.json` | **you**, after every iteration | the session record the CLI reads back |
+
+`improvements.json` is a **guide of likely wins ranked by what actually worked
+across other sites — it is not a script to apply blindly.** Probe whether a
+category applies to this site before spending an iteration on it, skip what
+does not apply, and trust your own profiling evidence over the checklist when
+they disagree.
+
+## Step 0 — get the site running
+
+Work out how this site is served (README, `package.json` scripts, Makefile,
+Procfile, docker-compose…). Get it running locally and identify the entry
+page real users hit first. If the repo has a production build step, measure
+the production build, not the dev server — dev servers lie about performance.
+
+## Step 1 — baseline profile
+
+Use the heaviest-hitting **real, user-felt** metric you can actually measure
+on this machine, preferring:
+
+1. **Lighthouse** if available or installable
+   (`npx lighthouse <url> --output=json --quiet --chrome-flags="--headless=new"`)
+   — gives FCP / LCP / TBT / TTI / Speed Index in one run.
+2. Headless Chromium via **Playwright/Puppeteer** if the repo already has one
+   — read `PerformanceNavigationTiming`, `largest-contentful-paint` entries,
+   and long tasks yourself.
+3. Last resort: **curl-level timings** (TTFB, full transfer time, total bytes
+   of the entry page + critical assets). Weak, but honest — record that this
+   is what you measured.
+
+Rules:
+
+- Measure **cold** (empty cache) and **warm** (second visit, cache primed)
+  whenever the tooling allows it.
+- **At least 3 runs per condition; use the median.** Record the spread — that
+  spread is your **noise floor** and the keep/revert rule below depends on it.
+- Pick a **north star**: LCP by default, or the closest proxy your tooling
+  produces. TTI is the secondary metric. If your tool cannot produce a TTI,
+  use a TBT-derived proxy or reuse the LCP value, and say so in
+  `results.json.profilingTool`.
+- Write the baseline into `results.json` **before touching any code**.
+
+## Step 2 — the loop
+
+One hypothesis per iteration, no exceptions:
+
+1. **Pick the most promising hypothesis.** Sources, in order: your own
+   profiling evidence (what is actually on the critical path?), then the
+   checklist categories that plausibly apply. Payload and critical-path work
+   usually beats micro-optimizations — see the impact ordering in the
+   speedup skill.
+2. **Implement the smallest change that tests the hypothesis.** Make it
+   cleanly revertable: commit it on the working branch (or `git stash`-able
+   state). If the repo is not git, snapshot the files you touch first.
+3. **Re-measure exactly like the baseline.** Same URL, same run count, same
+   conditions, median again. Never compare a 1-run number to a 3-run median.
+4. **Keep or revert, by the numbers:**
+   - A **serious improvement** means the north star improved beyond your
+     measured noise floor, AND by at least **5% or 20 ms** (whichever is
+     larger for the metric's scale). An FCP-only win that **regresses LCP
+     does not count** — that is rearranging deck chairs.
+   - Kept → record the iteration with `kept: true` and set
+     `missStreak` to `0` in `state.json`.
+   - Anything else → **revert completely** (revert means revert — no
+     half-kept experiments), record `kept: false`, and increment
+     `missStreak`.
+5. **Update `results.json` and `state.json` after every iteration.** Keep
+   `results.json` valid JSON at all times — the CLI parses it the moment you
+   exit, even if you were interrupted.
+
+## Step 3 — the stop rule
+
+When `missStreak` reaches `maxMisses` (default **5**) consecutive attempts
+with no serious improvement:
+
+1. Run one final full measurement pass (cold + warm) and write it to
+   `results.final`.
+2. Set `stoppedReason: "miss-streak"`, make sure every iteration is recorded,
+   and **exit your session**. The CLI takes over: it shows the user the end
+   screen and asks whether to loop more (it will reset the counter and
+   re-invoke you), submit site stats to the public site leaderboard, and/or
+   submit anonymous improvements data.
+
+Also stop (with `stoppedReason: "user"`) whenever the user asks you to.
+
+## Discipline (distilled from jjcm/speedupskill)
+
+- Measure first. A change you cannot measure is a change you revert.
+- One change per iteration — entangled changes teach nothing.
+- Numbers decide, not vibes. "It should be faster" is not a keep.
+- Do not merge lab harnesses, profiling scripts, or rejected experiments into
+  the site. Keep them in `.makefaster/` or delete them.
+- Reject known traps: preloading grid thumbnails, `fetchpriority` washes,
+  caching error responses, `srcset` rungs bigger than the CSS slot, and the
+  rest of the "what not to do" table in the speedup skill.
+- Copy the *shape* of known wins, not the file names. The full measured
+  technique catalog lives at `skill/SKILL.md` in
+  [jjcm/makefaster](https://github.com/jjcm/makefaster) (canonical copy,
+  mirrored from [jjcm/speedupskill](https://github.com/jjcm/speedupskill)).
+  Read it when picking hypotheses for load-time work.
+
+## `results.json` schema
+
+Keep this file valid and current after every iteration. All times are
+milliseconds. Deltas are negative when the site got faster.
+
+```json
+{
+  "version": 1,
+  "site": {
+    "url": "example.com",
+    "name": "Example",
+    "favicon": "https://example.com/favicon.ico"
+  },
+  "northStar": "lcp",
+  "profilingTool": "lighthouse 12.x, median of 3 runs, headless Chrome",
+  "noiseFloor": { "lcpMs": 40, "ttiMs": 60 },
+  "baseline": {
+    "cold": { "lcpMs": 2400, "ttiMs": 3900, "fcpMs": 1400, "tbtMs": 310 },
+    "warm": { "lcpMs": 1100, "ttiMs": 1700, "fcpMs": 600, "tbtMs": 120 }
+  },
+  "final": {
+    "cold": { "lcpMs": 1750, "ttiMs": 3050, "fcpMs": 1150, "tbtMs": 190 },
+    "warm": { "lcpMs": 780, "ttiMs": 1240, "fcpMs": 420, "tbtMs": 70 }
+  },
+  "iterations": [
+    {
+      "n": 1,
+      "name": "Inline critical CSS",
+      "description": "Inlined above-the-fold styles into the document head",
+      "category": "Inline Critical CSS",
+      "deltaMs": -260,
+      "deltaPct": -10.8,
+      "kept": true
+    },
+    {
+      "n": 2,
+      "name": "Preload first 8 thumbnails",
+      "description": "Preload hints for the first grid images",
+      "category": "Resource Preloading",
+      "deltaMs": 150,
+      "deltaPct": 6.2,
+      "kept": false
+    }
+  ],
+  "missStreak": 5,
+  "stoppedReason": "miss-streak"
+}
+```
+
+Field notes:
+
+- `site.url` — bare domain of the deployed site if the user told you or the
+  repo makes it obvious; otherwise leave the `site` object out and the CLI
+  will ask the user before submitting.
+- `site.favicon` — a favicon URL if the site has one (`<link rel="icon">` or
+  `/favicon.ico`); it is shown next to the URL on the site leaderboard.
+- `baseline` / `final` — medians per mode. Include the modes you measured;
+  `lcpMs` and `ttiMs` are required per included mode (they feed the site
+  leaderboard), `fcpMs` / `tbtMs` are welcome extras. `final` for a mode is
+  the last full measurement pass, re-run after the last kept change.
+- `iterations[].category` — the checklist category name this corresponds to,
+  or `null` when it is genuinely novel (the server will embed the name +
+  description and either fold it into the closest category or create a new
+  one on the improvement leaderboard).
+- `iterations[].deltaMs` / `deltaPct` — measured north-star change for that
+  single iteration (median vs. the previous kept state), negative = faster.
+- `missStreak` — mirror of the counter in `state.json` at exit time.
+- `stoppedReason` — `"miss-streak"`, `"user"`, or `null` while running.

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,174 @@
+# Makefaster leaderboard server
+
+A single zero-dependency Node process (`server.mjs`) that serves the marketing
+site, the live leaderboard data, and the two write APIs. It is the smallest
+thing that works: no framework, no database, no build step — one file store,
+seeded from the committed JSON.
+
+```bash
+node server/server.mjs
+# makefaster server listening on http://localhost:8787
+```
+
+Requires Node >= 18.17 (uses global `fetch` for the optional remote embedder).
+
+## What it serves
+
+| route | what |
+|---|---|
+| `GET /` + static files | the marketing site (repo root), unchanged |
+| `GET /data/sites.json` | **live** site-leaderboard rows from the store |
+| `GET /data/improvements.json` | **live** improvement categories from the store (the skill imports its top-50 checklist from here) |
+| `POST /api/submit-site` | one measurement run for one site |
+| `POST /api/submit-improvements` | anonymous improvements (embedding-matched into categories) |
+| `GET /api/health` | `{ ok, embedder, threshold }` |
+
+The static pages fetch `data/*.json` with relative paths, so behind this
+server the tables render live data; behind a dumb file server
+(`python3 -m http.server`) they render the committed seeds. Either way the
+marketing pages work.
+
+## The store
+
+On first boot the committed `data/sites.json` and `data/improvements.json`
+are copied into a writable data directory — default `server/.data/`
+(gitignored), override with `MAKEFASTER_DATA_DIR`. From then on the store owns
+those files: every accepted POST folds in and persists atomically
+(temp file + rename), so a crash can never tear the JSON. Back up the live
+boards by copying that directory.
+
+## Write API contracts
+
+### `POST /api/submit-site`
+
+```json
+{
+  "url": "example.com",
+  "mode": "cold",
+  "lcpRaw": 1750, "lcpDelta": -27.1,
+  "ttiRaw": 3050, "ttiDelta": -21.8,
+  "name": "Example",
+  "favicon": "https://example.com/favicon.ico"
+}
+```
+
+- `url` (required) is normalized to a bare hostname; `mode` is `cold` or
+  `warm`; raw values are milliseconds; deltas are percent vs. the pre-loop
+  baseline, **negative = faster**. `name`/`favicon` are optional (a
+  DuckDuckGo favicon URL and a capitalized domain label are derived
+  otherwise).
+- Upsert semantics per `(url, mode)`: metrics are replaced by the latest run,
+  the `tests` counter increments, `measuredAt` is set server-side.
+- Responses: `201` created / `200` updated with `{ ok, created, row }`;
+  `400 { ok: false, errors: [...] }` on invalid payloads.
+
+### `POST /api/submit-improvements`
+
+```json
+{
+  "improvements": [
+    { "name": "Inline critical CSS",
+      "description": "Inlined above-the-fold styles into the document head",
+      "deltaMs": -260, "deltaPct": -10.8 }
+  ]
+}
+```
+
+- **Anonymous by design**: no URL, no site identity. Any `url` field a client
+  sends is discarded before storage. Each entry needs `name` plus at least
+  one delta (negative = faster); 1–50 entries per submission.
+- Every entry is embedded (name + description) and compared to every current
+  category by cosine similarity:
+  - **similarity ≥ threshold** → that category's `count` increments and the
+    deltas fold into its running averages;
+  - **below threshold (novel)** → a new category is created on the
+    improvement leaderboard, seeded from the submission.
+  Ranks are recomputed (biggest average improvement first) and persisted, so
+  the HTML tables refresh on next load.
+- Response: `{ ok, results: [{ input, action: "matched"|"created", category,
+  similarity }], embedder, threshold }`.
+
+Try it locally:
+
+```bash
+curl -s localhost:8787/api/submit-improvements \
+  -H 'content-type: application/json' \
+  -d '{"improvements":[{"name":"Inline critical CSS","description":"Inlined above-the-fold styles","deltaMs":-260,"deltaPct":-10.8}]}'
+```
+
+## Embeddings
+
+Two backends behind one interface (see `lib/embedding.mjs`):
+
+- **local (default)** — a deterministic feature-hashing embedder (stemmed
+  words, word bigrams, character n-grams; 4096 dims, L2-normalized). No model
+  download, no GPU, no network, no key. Match threshold **0.3**, pinned by
+  the paraphrase/novel separation tests.
+- **remote (optional)** — any OpenAI-compatible `/v1/embeddings` endpoint:
+
+| env var | default | meaning |
+|---|---|---|
+| `MAKEFASTER_EMBEDDINGS_API_KEY` (or `OPENAI_API_KEY`) | — | enables the remote backend |
+| `MAKEFASTER_EMBEDDINGS_MODEL` | `text-embedding-3-small` | embedding model |
+| `MAKEFASTER_EMBEDDINGS_BASE_URL` | `https://api.openai.com/v1` | any OpenAI-compatible host |
+| `MAKEFASTER_MATCH_THRESHOLD` | 0.3 local / 0.55 remote | cosine fold-vs-create cutoff |
+
+Nothing is persisted in embedding space — each request embeds the incoming
+improvements *and* the current categories with the same backend, so backends
+can be switched freely. If the remote API fails mid-request the server falls
+back to the local embedder for that whole request (logged).
+
+## Configuration
+
+| env var | default | meaning |
+|---|---|---|
+| `PORT` | `8787` | listen port |
+| `HOST` | `0.0.0.0` | bind address |
+| `MAKEFASTER_DATA_DIR` | `server/.data` | writable store directory |
+
+Plus the embeddings vars above. Requests are rate-limited (60 POSTs/min/IP),
+bodies capped at 256 KB, and all responses carry permissive CORS headers so
+the static site can be hosted anywhere.
+
+## Deploying
+
+It is one file plus `lib/` — any box with Node 18+ works:
+
+```bash
+git clone https://github.com/jjcm/makefaster && cd makefaster
+MAKEFASTER_DATA_DIR=/var/lib/makefaster PORT=8787 node server/server.mjs
+```
+
+Systemd unit (the usual shape):
+
+```ini
+[Unit]
+Description=makefaster leaderboard server
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /opt/makefaster/server/server.mjs
+Environment=PORT=8787
+Environment=MAKEFASTER_DATA_DIR=/var/lib/makefaster
+Restart=on-failure
+DynamicUser=yes
+StateDirectory=makefaster
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Put a TLS-terminating proxy (Caddy/nginx/Cloudflare) in front and point the
+domain at it. The `npx makefaster` CLI submits to `https://makefaster.dev` by
+default; point it elsewhere with `--api` or `MAKEFASTER_API_BASE`.
+
+Hosting the static pages separately (e.g. GitHub Pages) also works: deploy
+only this server for the APIs and set the API origin on the pages before
+`js/api.js` loads:
+
+```html
+<script>window.MAKEFASTER_API_BASE = "https://api.your-host.dev";</script>
+```
+
+(the pages only read `data/*.json`; for live tables serve those two paths from
+this server too, or rewrite them at the proxy).

--- a/server/lib/categorize.mjs
+++ b/server/lib/categorize.mjs
@@ -1,0 +1,180 @@
+/**
+ * Fold submitted improvements into the improvement-category leaderboard.
+ *
+ * Every incoming improvement is embedded (name + description) and compared to
+ * every current category by cosine similarity:
+ *
+ *  - similarity >= threshold  -> increment that category's count and fold the
+ *    submitted deltas into its running averages;
+ *  - below threshold          -> the improvement is novel: a new category is
+ *    created on the leaderboard, seeded from the submission.
+ *
+ * Improvements inside one submission are processed sequentially against the
+ * growing category list, so two novel-but-similar entries in the same payload
+ * create one category, not two.
+ */
+
+import { cosineSimilarity } from "./embedding.mjs";
+
+const NAME_MAX = 80;
+const DESCRIPTION_MAX = 160;
+
+const SMALL_WORDS = new Set([
+  "a", "an", "and", "as", "at", "by", "for", "in", "of", "on", "or", "the",
+  "to", "via", "vs", "with",
+]);
+
+const ACRONYMS = new Map(Object.entries({
+  css: "CSS", js: "JS", html: "HTML", http: "HTTP", http2: "HTTP/2",
+  http3: "HTTP/3", api: "API", apis: "APIs", cdn: "CDN", svg: "SVG",
+  dom: "DOM", ssr: "SSR", csr: "CSR", lcp: "LCP", fcp: "FCP", tti: "TTI",
+  tbt: "TBT", inp: "INP", cls: "CLS", ttfb: "TTFB", quic: "QUIC",
+  avif: "AVIF", webp: "WebP", json: "JSON", url: "URL", urls: "URLs",
+  ui: "UI", db: "DB", sql: "SQL", spa: "SPA", pwa: "PWA", srcset: "srcset",
+}));
+
+/**
+ * "inline critical css" -> "Inline Critical CSS". Words the submitter already
+ * capitalized beyond the first letter (ORM, WebP, LCP) are preserved as-is.
+ */
+export function titleCaseCategoryName(raw) {
+  const words = String(raw).trim().replace(/\s+/g, " ").split(" ");
+  return words
+    .map((word, i) => {
+      if (/[A-Z]/.test(word.slice(1))) return word;
+      const lower = word.toLowerCase();
+      if (ACRONYMS.has(lower)) return ACRONYMS.get(lower);
+      if (i > 0 && i < words.length - 1 && SMALL_WORDS.has(lower)) return lower;
+      return lower.charAt(0).toUpperCase() + lower.slice(1);
+    })
+    .join(" ")
+    .slice(0, NAME_MAX);
+}
+
+/**
+ * The text a category or improvement is embedded from. The name is doubled so
+ * name tokens outweigh description tokens.
+ */
+export function embeddingText({ name, description }) {
+  const desc = description ? String(description) : "";
+  return `${name}. ${name}. ${desc}`;
+}
+
+function roundMs(value) {
+  return Math.round(value);
+}
+
+function roundPct(value) {
+  return Math.round(value * 10) / 10;
+}
+
+/**
+ * Running-average fold. `count` approximates the sample count for both
+ * metrics; submissions that omit one delta leave that average untouched,
+ * which slightly over-weights history for that metric — acceptable for a
+ * leaderboard, and it avoids tracking per-metric sample counts.
+ */
+function foldIntoCategory(category, improvement) {
+  const previousCount = category.count;
+  category.count = previousCount + 1;
+  if (typeof improvement.deltaMs === "number") {
+    const prevAvg = typeof category.avgImprovementMs === "number" ? category.avgImprovementMs : 0;
+    category.avgImprovementMs = roundMs(
+      (prevAvg * previousCount + improvement.deltaMs) / (previousCount + 1),
+    );
+  }
+  if (typeof improvement.deltaPct === "number") {
+    const prevAvg = typeof category.avgImprovementPct === "number" ? category.avgImprovementPct : 0;
+    category.avgImprovementPct = roundPct(
+      (prevAvg * previousCount + improvement.deltaPct) / (previousCount + 1),
+    );
+  }
+}
+
+function createCategoryFrom(improvement) {
+  return {
+    rank: 0, // assigned by rerankCategories below
+    name: titleCaseCategoryName(improvement.name),
+    description: String(improvement.description || "").trim().slice(0, DESCRIPTION_MAX)
+      || `Community-submitted: ${titleCaseCategoryName(improvement.name)}`,
+    count: 1,
+    avgImprovementMs: typeof improvement.deltaMs === "number" ? roundMs(improvement.deltaMs) : 0,
+    avgImprovementPct: typeof improvement.deltaPct === "number" ? roundPct(improvement.deltaPct) : 0,
+    icon: "default",
+  };
+}
+
+/**
+ * Leaderboard order: biggest average improvement first (deltas are negative,
+ * so ascending pct), count breaks ties, then name for stability.
+ */
+export function rerankCategories(categories) {
+  categories.sort((a, b) => {
+    const pctA = typeof a.avgImprovementPct === "number" ? a.avgImprovementPct : 0;
+    const pctB = typeof b.avgImprovementPct === "number" ? b.avgImprovementPct : 0;
+    if (pctA !== pctB) return pctA - pctB;
+    if (a.count !== b.count) return b.count - a.count;
+    return a.name.localeCompare(b.name);
+  });
+  categories.forEach((category, i) => {
+    category.rank = i + 1;
+  });
+  return categories;
+}
+
+/**
+ * @param {object} args
+ * @param {Array<{name: string, description?: string, deltaMs?: number, deltaPct?: number}>} args.improvements
+ * @param {Array<object>} args.categories current leaderboard rows (not mutated)
+ * @param {{id: string, embedMany(texts: string[]): Promise<Float64Array[]>}} args.embedder
+ * @param {number} args.threshold cosine similarity at/above which we fold
+ * @returns {Promise<{categories: Array<object>, results: Array<object>}>}
+ */
+export async function categorizeImprovements({ improvements, categories, embedder, threshold }) {
+  const working = categories.map((category) => ({ ...category }));
+
+  const texts = [
+    ...working.map((category) => embeddingText(category)),
+    ...improvements.map((improvement) => embeddingText(improvement)),
+  ];
+  const vectors = await embedder.embedMany(texts);
+  const categoryVectors = vectors.slice(0, working.length);
+  const improvementVectors = vectors.slice(working.length);
+
+  const results = [];
+  improvements.forEach((improvement, i) => {
+    const vector = improvementVectors[i];
+    let bestIndex = -1;
+    let bestSimilarity = -Infinity;
+    categoryVectors.forEach((categoryVector, j) => {
+      const similarity = cosineSimilarity(vector, categoryVector);
+      if (similarity > bestSimilarity) {
+        bestSimilarity = similarity;
+        bestIndex = j;
+      }
+    });
+
+    if (bestIndex !== -1 && bestSimilarity >= threshold) {
+      foldIntoCategory(working[bestIndex], improvement);
+      results.push({
+        input: improvement.name,
+        action: "matched",
+        category: working[bestIndex].name,
+        similarity: Math.round(bestSimilarity * 1000) / 1000,
+      });
+    } else {
+      const category = createCategoryFrom(improvement);
+      working.push(category);
+      categoryVectors.push(vector);
+      results.push({
+        input: improvement.name,
+        action: "created",
+        category: category.name,
+        similarity: bestIndex === -1 ? 0 : Math.round(bestSimilarity * 1000) / 1000,
+      });
+    }
+  });
+
+  rerankCategories(working);
+  return { categories: working, results };
+}

--- a/server/lib/embedding.mjs
+++ b/server/lib/embedding.mjs
@@ -1,0 +1,230 @@
+/**
+ * Text embeddings for improvement-category matching.
+ *
+ * Two backends behind one interface:
+ *
+ *  - local  — a deterministic feature-hashing embedder (signed hashed words,
+ *             word bigrams, and character n-grams, L2-normalized). No model
+ *             download, no GPU, no network. Good enough to match short
+ *             "what I sped up" blurbs against category names + descriptions.
+ *  - remote — any OpenAI-compatible /v1/embeddings endpoint, enabled by
+ *             setting MAKEFASTER_EMBEDDINGS_API_KEY (or OPENAI_API_KEY).
+ *             Model defaults to text-embedding-3-small; override with
+ *             MAKEFASTER_EMBEDDINGS_MODEL / MAKEFASTER_EMBEDDINGS_BASE_URL.
+ *
+ * Nothing is persisted in embedding space: every request embeds the incoming
+ * improvements AND the current categories with the same backend, so the two
+ * backends can never be compared against each other's vectors. If the remote
+ * backend fails mid-request we fall back to local for the whole request.
+ */
+
+// Short texts carry few word features, so hash collisions are the noise
+// floor; 4096 dims keeps random cross-text collisions negligible while a
+// 50-category board still fits in ~1.6 MB of vectors.
+const LOCAL_DIMS = 4096;
+const REMOTE_TIMEOUT_MS = 10_000;
+const DEFAULT_REMOTE_MODEL = "text-embedding-3-small";
+const DEFAULT_REMOTE_BASE_URL = "https://api.openai.com/v1";
+
+/**
+ * Cosine-similarity thresholds above which an incoming improvement is folded
+ * into an existing category instead of creating a new one. The local value is
+ * pinned by the paraphrase/novel separation tests in embedding.test.mjs.
+ */
+export const DEFAULT_MATCH_THRESHOLDS = { local: 0.3, remote: 0.55 };
+
+/**
+ * Words so generic in performance-speak that they match everything. They are
+ * dropped before hashing so "Improve image loading speed" is matched on
+ * image/loading, not on improve/speed.
+ */
+const STOPWORDS = new Set([
+  "a", "an", "and", "or", "of", "to", "in", "on", "for", "with", "by", "at",
+  "from", "into", "via", "the", "our", "your", "their", "its", "is", "are",
+  "was", "were", "be", "been", "it", "this", "that", "these", "those", "as",
+  "we", "you", "i", "using", "use", "used", "uses", "make", "makes", "made",
+  "making", "improve", "improved", "improves", "improvement", "improvements",
+  "optimize", "optimized", "optimizes", "optimization", "optimizations",
+  "reduce", "reduced", "reduces", "reducing", "better", "faster", "fast",
+  "slow", "slower", "speed", "speedup", "site", "sites", "website",
+  "websites", "page", "pages", "web", "app", "apps", "perf", "performance",
+  "now", "all", "more", "less", "new", "old", "time", "times",
+]);
+
+function fnv1a(str, seed) {
+  let h = seed >>> 0;
+  for (let i = 0; i < str.length; i++) {
+    h ^= str.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h >>> 0;
+}
+
+/**
+ * Very light suffix stemming so plural/verb forms hash to the same word
+ * feature (fonts/font, caching/cache/cached, subsetting/subset, images/image)
+ * without dragging in a stemming dependency. Char n-grams still bridge the
+ * forms this misses (compression/compress).
+ */
+function stem(token) {
+  let t = token;
+  if (t.length > 5 && t.endsWith("ing")) t = t.slice(0, -3);
+  else if (t.length > 4 && t.endsWith("ies")) t = `${t.slice(0, -3)}y`;
+  else if (t.length > 4 && t.endsWith("ed")) t = t.slice(0, -2);
+  else if (t.length > 4 && t.endsWith("es")) t = t.slice(0, -2);
+  else if (t.length > 3 && t.endsWith("s") && !t.endsWith("ss")) t = t.slice(0, -1);
+  if (t.length > 3 && t[t.length - 1] === t[t.length - 2]) t = t.slice(0, -1); // subsett -> subset
+  if (t.length > 4 && t.endsWith("e")) t = t.slice(0, -1); // cache/caching -> cach
+  return t;
+}
+
+function tokenize(text) {
+  const raw = String(text).toLowerCase().match(/[a-z0-9]+/g) || [];
+  return raw.filter((t) => t.length >= 2 && !STOPWORDS.has(t)).map(stem);
+}
+
+function addFeature(vector, feature, weight) {
+  const index = fnv1a(feature, 0x811c9dc5) % LOCAL_DIMS;
+  const sign = fnv1a(feature, 0x9747b28c) & 1 ? 1 : -1;
+  vector[index] += sign * weight;
+}
+
+/**
+ * Deterministic local embedding: signed feature hashing over word unigrams,
+ * word bigrams, and per-token character 3/4-grams (word-boundary marked so
+ * "compress"/"compression" overlap without random cross-word grams).
+ */
+export function localEmbed(text) {
+  const vector = new Float64Array(LOCAL_DIMS);
+  const tokens = tokenize(text);
+
+  for (const token of tokens) {
+    addFeature(vector, `w:${token}`, 2.0);
+    // Char n-grams only bridge morphology the stemmer misses, so they carry
+    // little weight — heavier grams let unrelated texts collide.
+    const padded = `^${token}$`;
+    for (let n = 3; n <= 4; n++) {
+      for (let i = 0; i + n <= padded.length; i++) {
+        addFeature(vector, `c${n}:${padded.slice(i, i + n)}`, n === 3 ? 0.35 : 0.5);
+      }
+    }
+  }
+  for (let i = 0; i + 1 < tokens.length; i++) {
+    addFeature(vector, `b:${tokens[i]}_${tokens[i + 1]}`, 1.5);
+  }
+
+  return l2Normalize(vector);
+}
+
+function l2Normalize(vector) {
+  let sumSquares = 0;
+  for (const v of vector) sumSquares += v * v;
+  if (sumSquares === 0) return vector;
+  const inv = 1 / Math.sqrt(sumSquares);
+  for (let i = 0; i < vector.length; i++) vector[i] *= inv;
+  return vector;
+}
+
+/** Cosine similarity of two L2-normalized vectors (plain dot product). */
+export function cosineSimilarity(a, b) {
+  if (a.length !== b.length) {
+    throw new Error(`cosineSimilarity: dimension mismatch ${a.length} vs ${b.length}`);
+  }
+  let dot = 0;
+  for (let i = 0; i < a.length; i++) dot += a[i] * b[i];
+  return dot;
+}
+
+function createLocalEmbedder() {
+  const cache = new Map();
+  return {
+    id: "local-hash-v1",
+    kind: "local",
+    async embedMany(texts) {
+      return texts.map((text) => {
+        let vector = cache.get(text);
+        if (!vector) {
+          vector = localEmbed(text);
+          cache.set(text, vector);
+        }
+        return vector;
+      });
+    },
+  };
+}
+
+async function requestRemoteEmbeddings({ baseUrl, apiKey, model, texts }) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), REMOTE_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${baseUrl.replace(/\/$/, "")}/embeddings`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({ model, input: texts }),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`embeddings API responded ${res.status}: ${body.slice(0, 200)}`);
+    }
+    const json = await res.json();
+    if (!Array.isArray(json.data) || json.data.length !== texts.length) {
+      throw new Error("embeddings API returned an unexpected payload shape");
+    }
+    const byIndex = [...json.data].sort((a, b) => a.index - b.index);
+    return byIndex.map((entry) => l2Normalize(Float64Array.from(entry.embedding)));
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function createRemoteEmbedder({ apiKey, baseUrl, model, logger }) {
+  const cache = new Map();
+  const local = createLocalEmbedder();
+  return {
+    id: `remote:${model}`,
+    kind: "remote",
+    async embedMany(texts) {
+      const missing = texts.filter((text) => !cache.has(text));
+      if (missing.length > 0) {
+        let vectors;
+        try {
+          vectors = await requestRemoteEmbeddings({ baseUrl, apiKey, model, texts: missing });
+        } catch (err) {
+          // Whole-request fallback keeps every comparison inside one
+          // embedding space; cached remote vectors are simply unused.
+          logger?.warn?.(`remote embeddings failed (${err.message}); falling back to local embedder for this request`);
+          return local.embedMany(texts);
+        }
+        missing.forEach((text, i) => cache.set(text, vectors[i]));
+      }
+      return texts.map((text) => cache.get(text));
+    },
+  };
+}
+
+/**
+ * Pick the embedding backend from the environment. Also resolves the match
+ * threshold: MAKEFASTER_MATCH_THRESHOLD overrides the per-backend default.
+ */
+export function createEmbedder(env = process.env, logger = console) {
+  const apiKey = env.MAKEFASTER_EMBEDDINGS_API_KEY || env.OPENAI_API_KEY;
+  const embedder = apiKey
+    ? createRemoteEmbedder({
+        apiKey,
+        baseUrl: env.MAKEFASTER_EMBEDDINGS_BASE_URL || DEFAULT_REMOTE_BASE_URL,
+        model: env.MAKEFASTER_EMBEDDINGS_MODEL || DEFAULT_REMOTE_MODEL,
+        logger,
+      })
+    : createLocalEmbedder();
+
+  const override = Number.parseFloat(env.MAKEFASTER_MATCH_THRESHOLD || "");
+  const threshold = Number.isFinite(override) && override > 0 && override < 1
+    ? override
+    : DEFAULT_MATCH_THRESHOLDS[embedder.kind];
+
+  return { embedder, threshold };
+}

--- a/server/lib/sites.mjs
+++ b/server/lib/sites.mjs
@@ -1,0 +1,80 @@
+/**
+ * Site-leaderboard row management: URL normalization and upsert of one
+ * measurement run into the rows list (one row per site per cold/warm mode).
+ */
+
+const NAME_MAX = 80;
+
+/**
+ * Normalize whatever the submitter sent ("https://Example.com/path",
+ * "www.example.com", "example.com") to a bare lowercase hostname.
+ * Returns null when it cannot be read as a hostname.
+ */
+export function normalizeSiteUrl(input) {
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  if (!trimmed || trimmed.length > 300) return null;
+
+  let hostname;
+  try {
+    hostname = new URL(/^[a-z][a-z0-9+.-]*:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`).hostname;
+  } catch {
+    return null;
+  }
+
+  hostname = hostname.toLowerCase().replace(/^www\./, "").replace(/\.$/, "");
+  // Require a dotted hostname of sane label characters; localhost and bare
+  // hosts are fine for local testing but have no place on a public board.
+  if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/.test(hostname)) {
+    return null;
+  }
+  if (hostname.length > 253) return null;
+  return hostname;
+}
+
+/** "docs.example.com" -> "Example" — a display-name fallback. */
+export function displayNameForUrl(url) {
+  const labels = url.split(".");
+  const core = labels.length >= 2 ? labels[labels.length - 2] : labels[0];
+  return core.charAt(0).toUpperCase() + core.slice(1);
+}
+
+export function defaultFaviconForUrl(url) {
+  return `https://icons.duckduckgo.com/ip3/${url}.ico`;
+}
+
+/**
+ * Upsert one validated measurement into the rows list.
+ * Existing (url, mode) row: metrics are replaced by the latest run, the test
+ * counter increments, and name/favicon refresh when provided. New row: test
+ * counter starts at 1.
+ *
+ * @returns {{rows: Array<object>, row: object, created: boolean}}
+ */
+export function upsertSite(rows, submission, nowIso) {
+  const next = rows.map((row) => ({ ...row }));
+  const index = next.findIndex(
+    (row) => row.url === submission.url && row.mode === submission.mode,
+  );
+
+  const base = index === -1 ? null : next[index];
+  const row = {
+    name: (submission.name || base?.name || displayNameForUrl(submission.url)).slice(0, NAME_MAX),
+    url: submission.url,
+    favicon: submission.favicon || base?.favicon || defaultFaviconForUrl(submission.url),
+    lcpRaw: submission.lcpRaw,
+    lcpDelta: submission.lcpDelta,
+    ttiRaw: submission.ttiRaw,
+    ttiDelta: submission.ttiDelta,
+    mode: submission.mode,
+    tests: (base?.tests || 0) + 1,
+    measuredAt: nowIso,
+  };
+
+  if (index === -1) {
+    next.push(row);
+  } else {
+    next[index] = row;
+  }
+  return { rows: next, row, created: index === -1 };
+}

--- a/server/lib/store.mjs
+++ b/server/lib/store.mjs
@@ -1,0 +1,63 @@
+/**
+ * JSON-file persistence for the two leaderboards.
+ *
+ * The committed files in data/ are the seed dataset; the live store copies
+ * them into a writable data directory (default server/.data, override with
+ * MAKEFASTER_DATA_DIR) on first boot and owns them from then on. Writes are
+ * atomic (temp file + rename) so a crash can never leave a torn JSON file,
+ * and the HTML tables can refresh from GET /data/*.json at any time.
+ */
+
+import { mkdirSync, readFileSync, renameSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+export class Store {
+  /**
+   * @param {{dataDir: string, seedDir: string}} args
+   *  dataDir — writable directory owned by the store
+   *  seedDir — directory holding the committed sites.json / improvements.json
+   */
+  constructor({ dataDir, seedDir }) {
+    this.dataDir = dataDir;
+    this.seedDir = seedDir;
+    mkdirSync(dataDir, { recursive: true });
+    this.sites = this.#loadCollection("sites.json");
+    this.improvements = this.#loadCollection("improvements.json");
+  }
+
+  #loadCollection(filename) {
+    const livePath = join(this.dataDir, filename);
+    if (existsSync(livePath)) {
+      return JSON.parse(readFileSync(livePath, "utf8"));
+    }
+    const seedPath = join(this.seedDir, filename);
+    const seeded = existsSync(seedPath) ? JSON.parse(readFileSync(seedPath, "utf8")) : [];
+    this.#persist(filename, seeded);
+    return seeded;
+  }
+
+  #persist(filename, rows) {
+    const target = join(this.dataDir, filename);
+    const temp = join(this.dataDir, `.${filename}.${process.pid}.tmp`);
+    writeFileSync(temp, JSON.stringify(rows, null, 1) + "\n");
+    renameSync(temp, target);
+  }
+
+  getSites() {
+    return this.sites;
+  }
+
+  getImprovements() {
+    return this.improvements;
+  }
+
+  replaceSites(rows) {
+    this.sites = rows;
+    this.#persist("sites.json", rows);
+  }
+
+  replaceImprovements(rows) {
+    this.improvements = rows;
+    this.#persist("improvements.json", rows);
+  }
+}

--- a/server/lib/validate.mjs
+++ b/server/lib/validate.mjs
@@ -1,0 +1,126 @@
+/**
+ * Request-body validation for the two write endpoints. These are the public
+ * system boundary, so everything is checked and clamped here; the rest of the
+ * server trusts validated values.
+ */
+
+import { normalizeSiteUrl } from "./sites.mjs";
+
+const MODES = new Set(["cold", "warm"]);
+const RAW_MS_MAX = 600_000; // ten minutes — beyond that it's garbage, not slow
+const DELTA_MS_LIMIT = 600_000;
+const DELTA_PCT_MIN = -100; // can't get more than 100% faster
+const DELTA_PCT_MAX = 500;
+const IMPROVEMENTS_MAX = 50;
+const NAME_MAX = 120;
+const DESCRIPTION_MAX = 500;
+
+function finiteInRange(value, min, max) {
+  return typeof value === "number" && Number.isFinite(value) && value >= min && value <= max;
+}
+
+function isHttpUrl(value) {
+  if (typeof value !== "string" || value.length > 500) return false;
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" || url.protocol === "http:";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * POST /api/submit-site
+ * { url, favicon?, name?, lcpRaw, lcpDelta, ttiRaw, ttiDelta, mode: cold|warm }
+ * Deltas are percentages vs. the pre-loop baseline; negative = faster.
+ */
+export function validateSitePayload(body) {
+  const errors = [];
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, errors: ["payload must be a JSON object"] };
+  }
+
+  const url = normalizeSiteUrl(body.url);
+  if (!url) errors.push("url must be a valid public hostname, e.g. \"example.com\"");
+  if (!MODES.has(body.mode)) errors.push("mode must be \"cold\" or \"warm\"");
+  if (!finiteInRange(body.lcpRaw, 0, RAW_MS_MAX)) errors.push(`lcpRaw must be a number of ms between 0 and ${RAW_MS_MAX}`);
+  if (!finiteInRange(body.ttiRaw, 0, RAW_MS_MAX)) errors.push(`ttiRaw must be a number of ms between 0 and ${RAW_MS_MAX}`);
+  if (!finiteInRange(body.lcpDelta, DELTA_PCT_MIN, DELTA_PCT_MAX)) errors.push(`lcpDelta must be a percentage between ${DELTA_PCT_MIN} and ${DELTA_PCT_MAX} (negative = faster)`);
+  if (!finiteInRange(body.ttiDelta, DELTA_PCT_MIN, DELTA_PCT_MAX)) errors.push(`ttiDelta must be a percentage between ${DELTA_PCT_MIN} and ${DELTA_PCT_MAX} (negative = faster)`);
+  if (body.favicon !== undefined && body.favicon !== null && !isHttpUrl(body.favicon)) errors.push("favicon must be an http(s) URL when provided");
+  if (body.name !== undefined && body.name !== null && (typeof body.name !== "string" || body.name.trim().length === 0 || body.name.length > 200)) errors.push("name must be a short string when provided");
+
+  if (errors.length > 0) return { ok: false, errors };
+  return {
+    ok: true,
+    value: {
+      url,
+      mode: body.mode,
+      lcpRaw: Math.round(body.lcpRaw),
+      lcpDelta: Math.round(body.lcpDelta * 10) / 10,
+      ttiRaw: Math.round(body.ttiRaw),
+      ttiDelta: Math.round(body.ttiDelta * 10) / 10,
+      ...(body.favicon ? { favicon: body.favicon } : {}),
+      ...(typeof body.name === "string" && body.name.trim() ? { name: body.name.trim() } : {}),
+    },
+  };
+}
+
+/**
+ * POST /api/submit-improvements — anonymous by design.
+ * { improvements: [{ name, description?, deltaMs?, deltaPct? }] }
+ * Any url/site field a client sends is discarded, never stored. Each entry
+ * needs a name and at least one delta (negative = faster).
+ */
+export function validateImprovementsPayload(body) {
+  const errors = [];
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return { ok: false, errors: ["payload must be a JSON object"] };
+  }
+  if (!Array.isArray(body.improvements) || body.improvements.length === 0) {
+    return { ok: false, errors: ["improvements must be a non-empty array"] };
+  }
+  if (body.improvements.length > IMPROVEMENTS_MAX) {
+    return { ok: false, errors: [`improvements is capped at ${IMPROVEMENTS_MAX} entries per submission`] };
+  }
+
+  const value = [];
+  body.improvements.forEach((entry, i) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      errors.push(`improvements[${i}] must be an object`);
+      return;
+    }
+    const name = typeof entry.name === "string" ? entry.name.trim() : "";
+    if (!name || name.length > NAME_MAX) {
+      errors.push(`improvements[${i}].name must be a 1–${NAME_MAX} character string`);
+      return;
+    }
+    const hasMs = entry.deltaMs !== undefined && entry.deltaMs !== null;
+    const hasPct = entry.deltaPct !== undefined && entry.deltaPct !== null;
+    if (hasMs && !finiteInRange(entry.deltaMs, -DELTA_MS_LIMIT, DELTA_MS_LIMIT)) {
+      errors.push(`improvements[${i}].deltaMs must be a number of ms (negative = faster)`);
+      return;
+    }
+    if (hasPct && !finiteInRange(entry.deltaPct, DELTA_PCT_MIN, DELTA_PCT_MAX)) {
+      errors.push(`improvements[${i}].deltaPct must be a percentage (negative = faster)`);
+      return;
+    }
+    if (!hasMs && !hasPct) {
+      errors.push(`improvements[${i}] needs at least one of deltaMs or deltaPct`);
+      return;
+    }
+    if (entry.description !== undefined && entry.description !== null && typeof entry.description !== "string") {
+      errors.push(`improvements[${i}].description must be a string when provided`);
+      return;
+    }
+    value.push({
+      name,
+      description: typeof entry.description === "string" ? entry.description.trim().slice(0, DESCRIPTION_MAX) : "",
+      ...(hasMs ? { deltaMs: entry.deltaMs } : {}),
+      ...(hasPct ? { deltaPct: entry.deltaPct } : {}),
+    });
+  });
+
+  if (errors.length > 0) return { ok: false, errors };
+  return { ok: true, value };
+}

--- a/server/server.mjs
+++ b/server/server.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * The Makefaster leaderboard server — a single zero-dependency Node process.
+ *
+ *   node server/server.mjs            # http://localhost:8787
+ *
+ * It serves three things:
+ *   1. the static marketing site (repo root), unchanged;
+ *   2. live leaderboard data:  GET /data/sites.json, GET /data/improvements.json
+ *      (served from the persistent store, seeded from the committed data/);
+ *   3. the write APIs:         POST /api/submit-site, POST /api/submit-improvements.
+ *
+ * The static pages also work under any dumb file server (python3 -m
+ * http.server) — they just read the committed JSON and never POST. This
+ * process is only required for live submissions. See server/README.md for
+ * configuration and deploy notes.
+ */
+
+import { createServer } from "node:http";
+import { readFile, stat } from "node:fs/promises";
+import { dirname, extname, join, normalize, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Store } from "./lib/store.mjs";
+import { createEmbedder } from "./lib/embedding.mjs";
+import { categorizeImprovements } from "./lib/categorize.mjs";
+import { upsertSite } from "./lib/sites.mjs";
+import { validateImprovementsPayload, validateSitePayload } from "./lib/validate.mjs";
+
+const SERVER_DIR = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_PORT = 8787;
+const BODY_LIMIT_BYTES = 256 * 1024;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const RATE_LIMIT_MAX_POSTS = 60;
+
+const MIME_TYPES = {
+  ".html": "text/html; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".ico": "image/x-icon",
+  ".txt": "text/plain; charset=utf-8",
+  ".md": "text/markdown; charset=utf-8",
+  ".woff2": "font/woff2",
+};
+
+function corsHeaders() {
+  return {
+    "access-control-allow-origin": "*",
+    "access-control-allow-methods": "GET, POST, OPTIONS",
+    "access-control-allow-headers": "content-type",
+  };
+}
+
+function sendJson(res, status, payload) {
+  const body = JSON.stringify(payload, null, 1);
+  res.writeHead(status, {
+    "content-type": "application/json; charset=utf-8",
+    "content-length": Buffer.byteLength(body),
+    "cache-control": "no-store",
+    ...corsHeaders(),
+  });
+  res.end(body);
+}
+
+function readJsonBody(req) {
+  return new Promise((resolvePromise, rejectPromise) => {
+    const chunks = [];
+    let received = 0;
+    req.on("data", (chunk) => {
+      received += chunk.length;
+      if (received > BODY_LIMIT_BYTES) {
+        rejectPromise(Object.assign(new Error("payload too large"), { statusCode: 413 }));
+        req.destroy();
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => {
+      try {
+        resolvePromise(JSON.parse(Buffer.concat(chunks).toString("utf8") || "null"));
+      } catch {
+        rejectPromise(Object.assign(new Error("body must be valid JSON"), { statusCode: 400 }));
+      }
+    });
+    req.on("error", rejectPromise);
+  });
+}
+
+function createRateLimiter() {
+  const buckets = new Map();
+  return function allow(ip) {
+    const now = Date.now();
+    const bucket = buckets.get(ip);
+    if (!bucket || now - bucket.windowStart >= RATE_LIMIT_WINDOW_MS) {
+      buckets.set(ip, { windowStart: now, count: 1 });
+      return true;
+    }
+    bucket.count += 1;
+    if (buckets.size > 10_000) buckets.clear(); // crude memory ceiling
+    return bucket.count <= RATE_LIMIT_MAX_POSTS;
+  };
+}
+
+/**
+ * @param {object} [options]
+ * @param {string} [options.rootDir] static-site root (defaults to repo root)
+ * @param {string} [options.dataDir] writable store dir (default server/.data)
+ * @param {object} [options.env]     environment (embedding config)
+ * @param {object} [options.logger]
+ */
+export function createMakefasterServer(options = {}) {
+  const rootDir = resolve(options.rootDir || join(SERVER_DIR, ".."));
+  const dataDir = resolve(
+    options.dataDir || options.env?.MAKEFASTER_DATA_DIR || process.env.MAKEFASTER_DATA_DIR || join(SERVER_DIR, ".data"),
+  );
+  const env = options.env || process.env;
+  const logger = options.logger || console;
+
+  const store = new Store({ dataDir, seedDir: join(rootDir, "data") });
+  const { embedder, threshold } = createEmbedder(env, logger);
+  const allowPost = createRateLimiter();
+
+  // Serialize writes: one request folds into the store at a time so two
+  // concurrent submissions cannot lose each other's rows.
+  let writeChain = Promise.resolve();
+  function serialized(task) {
+    const next = writeChain.then(task, task);
+    writeChain = next.catch(() => {});
+    return next;
+  }
+
+  async function handleSubmitSite(req, res) {
+    const body = await readJsonBody(req);
+    const validated = validateSitePayload(body);
+    if (!validated.ok) {
+      sendJson(res, 400, { ok: false, errors: validated.errors });
+      return;
+    }
+    const result = await serialized(async () => {
+      const outcome = upsertSite(store.getSites(), validated.value, new Date().toISOString());
+      store.replaceSites(outcome.rows);
+      return outcome;
+    });
+    logger.info?.(`submit-site: ${result.created ? "created" : "updated"} ${validated.value.url} (${validated.value.mode})`);
+    sendJson(res, result.created ? 201 : 200, { ok: true, created: result.created, row: result.row });
+  }
+
+  async function handleSubmitImprovements(req, res) {
+    const body = await readJsonBody(req);
+    const validated = validateImprovementsPayload(body);
+    if (!validated.ok) {
+      sendJson(res, 400, { ok: false, errors: validated.errors });
+      return;
+    }
+    const outcome = await serialized(async () => {
+      const { categories, results } = await categorizeImprovements({
+        improvements: validated.value,
+        categories: store.getImprovements(),
+        embedder,
+        threshold,
+      });
+      store.replaceImprovements(categories);
+      return results;
+    });
+    logger.info?.(
+      `submit-improvements: ${outcome.filter((r) => r.action === "matched").length} matched, ` +
+      `${outcome.filter((r) => r.action === "created").length} new categories (embedder ${embedder.id})`,
+    );
+    sendJson(res, 200, { ok: true, results: outcome, embedder: embedder.id, threshold });
+  }
+
+  async function handleStatic(req, res, pathname) {
+    const relative = pathname === "/" ? "index.html" : decodeURIComponent(pathname.slice(1));
+    const filePath = normalize(join(rootDir, relative));
+    if (!filePath.startsWith(rootDir + sep) && filePath !== rootDir) {
+      sendJson(res, 404, { ok: false, errors: ["not found"] });
+      return;
+    }
+    let stats;
+    try {
+      stats = await stat(filePath);
+    } catch {
+      sendJson(res, 404, { ok: false, errors: ["not found"] });
+      return;
+    }
+    if (stats.isDirectory()) {
+      sendJson(res, 404, { ok: false, errors: ["not found"] });
+      return;
+    }
+    const type = MIME_TYPES[extname(filePath).toLowerCase()] || "application/octet-stream";
+    const body = await readFile(filePath);
+    res.writeHead(200, {
+      "content-type": type,
+      "content-length": body.length,
+      "cache-control": type.startsWith("text/html") ? "no-cache" : "public, max-age=300",
+      ...corsHeaders(),
+    });
+    res.end(req.method === "HEAD" ? undefined : body);
+  }
+
+  const server = createServer(async (req, res) => {
+    const url = new URL(req.url, "http://localhost");
+    const pathname = url.pathname;
+
+    try {
+      if (req.method === "OPTIONS") {
+        res.writeHead(204, corsHeaders());
+        res.end();
+        return;
+      }
+
+      if (req.method === "POST") {
+        const ip = req.socket.remoteAddress || "unknown";
+        if (!allowPost(ip)) {
+          sendJson(res, 429, { ok: false, errors: ["rate limit exceeded — try again in a minute"] });
+          return;
+        }
+        if (pathname === "/api/submit-site") {
+          await handleSubmitSite(req, res);
+          return;
+        }
+        if (pathname === "/api/submit-improvements") {
+          await handleSubmitImprovements(req, res);
+          return;
+        }
+        sendJson(res, 404, { ok: false, errors: ["unknown endpoint"] });
+        return;
+      }
+
+      if (req.method === "GET" || req.method === "HEAD") {
+        // Live leaderboard data always comes from the store, never the
+        // committed seed files, so the tables reflect submissions.
+        if (pathname === "/data/sites.json") {
+          sendJson(res, 200, store.getSites());
+          return;
+        }
+        if (pathname === "/data/improvements.json") {
+          sendJson(res, 200, store.getImprovements());
+          return;
+        }
+        if (pathname === "/api/health") {
+          sendJson(res, 200, { ok: true, embedder: embedder.id, threshold });
+          return;
+        }
+        await handleStatic(req, res, pathname);
+        return;
+      }
+
+      sendJson(res, 405, { ok: false, errors: ["method not allowed"] });
+    } catch (err) {
+      const status = err?.statusCode || 500;
+      if (status >= 500) logger.error?.(`request failed: ${err?.stack || err}`);
+      if (!res.headersSent) {
+        sendJson(res, status, { ok: false, errors: [status >= 500 ? "internal error" : err.message] });
+      } else {
+        res.destroy();
+      }
+    }
+  });
+
+  return { server, store, dataDir, embedder, threshold };
+}
+
+const isMain = process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMain) {
+  const port = Number.parseInt(process.env.PORT || "", 10) || DEFAULT_PORT;
+  const host = process.env.HOST || "0.0.0.0";
+  const { server, dataDir, embedder } = createMakefasterServer();
+  server.listen(port, host, () => {
+    console.log(`makefaster server listening on http://${host === "0.0.0.0" ? "localhost" : host}:${port}`);
+    console.log(`  store:    ${dataDir}`);
+    console.log(`  embedder: ${embedder.id}`);
+  });
+}

--- a/server/test/categorize.test.mjs
+++ b/server/test/categorize.test.mjs
@@ -1,0 +1,133 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  categorizeImprovements,
+  rerankCategories,
+  titleCaseCategoryName,
+} from "../lib/categorize.mjs";
+import { createEmbedder } from "../lib/embedding.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const CATEGORIES = JSON.parse(readFileSync(join(ROOT, "data", "improvements.json"), "utf8"));
+
+function localSetup() {
+  const { embedder, threshold } = createEmbedder({}, { warn() {} });
+  return { embedder, threshold };
+}
+
+test("matched improvement increments count and folds averages", async () => {
+  const { embedder, threshold } = localSetup();
+  const before = CATEGORIES.find((c) => c.name === "Image Optimization");
+  const { categories, results } = await categorizeImprovements({
+    improvements: [{
+      name: "Compress hero images",
+      description: "Compressed and resized the oversized hero images",
+      deltaMs: -600,
+      deltaPct: -30,
+    }],
+    categories: CATEGORIES,
+    embedder,
+    threshold,
+  });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0].action, "matched");
+  assert.equal(results[0].category, "Image Optimization");
+
+  const after = categories.find((c) => c.name === "Image Optimization");
+  assert.equal(after.count, before.count + 1);
+  const expectedMs = Math.round((before.avgImprovementMs * before.count - 600) / (before.count + 1));
+  const expectedPct = Math.round(((before.avgImprovementPct * before.count - 30) / (before.count + 1)) * 10) / 10;
+  assert.equal(after.avgImprovementMs, expectedMs);
+  assert.equal(after.avgImprovementPct, expectedPct);
+
+  // input list must not be mutated
+  assert.equal(CATEGORIES.find((c) => c.name === "Image Optimization").count, before.count);
+});
+
+test("novel improvement creates a title-cased category with count 1", async () => {
+  const { embedder, threshold } = localSetup();
+  const { categories, results } = await categorizeImprovements({
+    improvements: [{
+      name: "rewrite the ORM in rust",
+      description: "Rewrote the ORM data layer in Rust",
+      deltaMs: -350,
+      deltaPct: -12.34,
+    }],
+    categories: CATEGORIES,
+    embedder,
+    threshold,
+  });
+
+  assert.equal(results[0].action, "created");
+  assert.equal(categories.length, CATEGORIES.length + 1);
+  const created = categories.find((c) => c.name === "Rewrite the ORM in Rust");
+  assert.ok(created, `created category missing; got ${results[0].category}`);
+  assert.equal(created.count, 1);
+  assert.equal(created.avgImprovementMs, -350);
+  assert.equal(created.avgImprovementPct, -12.3);
+  assert.equal(created.icon, "default");
+  assert.ok(created.rank >= 1);
+});
+
+test("two similar novel entries in one submission create one category, not two", async () => {
+  const { embedder, threshold } = localSetup();
+  const { categories, results } = await categorizeImprovements({
+    improvements: [
+      { name: "Precompile route manifests", description: "Precompiled the route manifest lookup table at build time", deltaMs: -80, deltaPct: -4 },
+      { name: "Precompile the route manifest", description: "Route manifest lookup table now precompiled at build time", deltaMs: -60, deltaPct: -3 },
+    ],
+    categories: CATEGORIES,
+    embedder,
+    threshold,
+  });
+
+  assert.equal(results[0].action, "created");
+  assert.equal(results[1].action, "matched", `second entry should fold into the first's new category, got ${JSON.stringify(results[1])}`);
+  assert.equal(results[1].category, results[0].category);
+  assert.equal(categories.length, CATEGORIES.length + 1);
+  const created = categories.find((c) => c.name === results[0].category);
+  assert.equal(created.count, 2);
+  assert.equal(created.avgImprovementMs, -70);
+  assert.equal(created.avgImprovementPct, -3.5);
+});
+
+test("missing deltaMs folds count and pct but leaves ms average alone", async () => {
+  const { embedder, threshold } = localSetup();
+  const before = CATEGORIES.find((c) => c.name === "Tree Shaking");
+  const { categories } = await categorizeImprovements({
+    improvements: [{
+      name: "Remove unused JavaScript",
+      description: "Tree-shook the main bundle and dropped dead code",
+      deltaPct: -10,
+    }],
+    categories: CATEGORIES,
+    embedder,
+    threshold,
+  });
+  const after = categories.find((c) => c.name === "Tree Shaking");
+  assert.equal(after.count, before.count + 1);
+  assert.equal(after.avgImprovementMs, before.avgImprovementMs);
+  assert.notEqual(after.avgImprovementPct, before.avgImprovementPct);
+});
+
+test("rerankCategories orders by avg pct (most improvement first) and reassigns ranks", () => {
+  const rows = [
+    { name: "B", avgImprovementPct: -5, count: 10 },
+    { name: "A", avgImprovementPct: -20, count: 1 },
+    { name: "C", avgImprovementPct: -5, count: 20 },
+  ];
+  rerankCategories(rows);
+  assert.deepEqual(rows.map((r) => r.name), ["A", "C", "B"]);
+  assert.deepEqual(rows.map((r) => r.rank), [1, 2, 3]);
+});
+
+test("titleCaseCategoryName handles acronyms and small words", () => {
+  assert.equal(titleCaseCategoryName("inline critical css"), "Inline Critical CSS");
+  assert.equal(titleCaseCategoryName("preconnect to the font origin"), "Preconnect to the Font Origin");
+  assert.equal(titleCaseCategoryName("serve avif and webp images"), "Serve AVIF and WebP Images");
+  assert.equal(titleCaseCategoryName("  http2   server push  "), "HTTP/2 Server Push");
+});

--- a/server/test/embedding.test.mjs
+++ b/server/test/embedding.test.mjs
@@ -1,0 +1,115 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  localEmbed,
+  cosineSimilarity,
+  createEmbedder,
+  DEFAULT_MATCH_THRESHOLDS,
+} from "../lib/embedding.mjs";
+import { embeddingText } from "../lib/categorize.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const CATEGORIES = JSON.parse(readFileSync(join(ROOT, "data", "improvements.json"), "utf8"));
+
+test("localEmbed is deterministic and L2-normalized", () => {
+  const a = localEmbed("Enable Brotli compression for text assets");
+  const b = localEmbed("Enable Brotli compression for text assets");
+  assert.deepEqual([...a], [...b]);
+  let norm = 0;
+  for (const v of a) norm += v * v;
+  assert.ok(Math.abs(norm - 1) < 1e-9, `expected unit norm, got ${norm}`);
+});
+
+test("cosineSimilarity: identical texts are 1, empty is orthogonal-safe", () => {
+  const a = localEmbed("inline critical css");
+  assert.ok(Math.abs(cosineSimilarity(a, a) - 1) < 1e-9);
+  const empty = localEmbed("");
+  assert.equal(cosineSimilarity(a, empty), 0);
+});
+
+test("createEmbedder picks local backend without API key and honors threshold override", () => {
+  const { embedder, threshold } = createEmbedder({}, { warn() {} });
+  assert.equal(embedder.kind, "local");
+  assert.equal(threshold, DEFAULT_MATCH_THRESHOLDS.local);
+
+  const { threshold: overridden } = createEmbedder({ MAKEFASTER_MATCH_THRESHOLD: "0.62" });
+  assert.equal(overridden, 0.62);
+});
+
+test("createEmbedder picks remote backend when a key is present", () => {
+  const { embedder, threshold } = createEmbedder({ OPENAI_API_KEY: "sk-test" });
+  assert.equal(embedder.kind, "remote");
+  assert.equal(threshold, DEFAULT_MATCH_THRESHOLDS.remote);
+});
+
+/**
+ * The load-bearing property: real-world paraphrases of known categories score
+ * above the default local threshold against their category, and genuinely
+ * novel improvements score below it against every category. This test pins
+ * DEFAULT_MATCH_THRESHOLDS.local. Inputs mirror what the skill actually
+ * submits: a short name plus a one-line description.
+ */
+const PARAPHRASES = [
+  { name: "Enable Brotli on text assets", description: "Enabled Brotli compression for HTML, CSS and JS responses", expect: ["Gzip / Brotli Compression", "Enable Text Compression"] },
+  { name: "Compress hero images", description: "Compressed and resized the oversized hero images", expect: ["Image Optimization"] },
+  { name: "Remove unused JavaScript", description: "Tree-shook the main bundle and dropped dead code", expect: ["Tree Shaking"] },
+  { name: "Inline critical CSS", description: "Inlined above-the-fold styles into the document head", expect: ["Inline Critical CSS"] },
+  { name: "Lazy load below-fold images", description: "Deferred offscreen images with loading=lazy", expect: ["Lazy-Load Below-Fold Images"] },
+  { name: "Defer third-party scripts", description: "Analytics and chat widgets now load after interactive", expect: ["Defer Third-Party Scripts"] },
+  { name: "Subset web fonts", description: "Shipped only the glyphs the pages actually use", expect: ["Font Subsetting", "Font Optimization"] },
+  { name: "Serve AVIF images", description: "Switched product images from JPEG to AVIF format", expect: ["AVIF / WebP Image Formats"] },
+  { name: "Preload the LCP image", description: "Added a preload hint for the largest contentful paint image", expect: ["Preload LCP Image", "Resource Preloading"] },
+  { name: "Preconnect to font origin", description: "Added preconnect hints for the font CDN origin", expect: ["Preconnect To Required Origins"] },
+  { name: "Enable gzip on API responses", description: "Turned on gzip text compression for JSON API responses", expect: ["Gzip / Brotli Compression", "Enable Text Compression"] },
+  { name: "Split bundle by route", description: "Split the vendor bundle along navigation route boundaries", expect: ["Code Splitting By Route"] },
+  { name: "Add service worker caching", description: "Cache the app shell and static assets for repeat visits", expect: ["Service Worker Caching"] },
+  { name: "Immutable cache for hashed assets", description: "Set long cache lifetimes on content-hashed static assets", expect: ["Content-Hashed Immutable Assets", "Cache Header Improvements"] },
+  { name: "Resize images at the CDN edge", description: "Moved image resizing and recompression to the edge", expect: ["Image CDN Transformations"] },
+];
+
+const NOVEL = [
+  { name: "Rewrite ORM in Rust", description: "Rewrote the ORM data layer in Rust" },
+  { name: "Upgrade database hardware", description: "Upgraded the Postgres instance to a bigger machine" },
+  { name: "Buy a faster office chair", description: "Bought a faster office chair for the developers" },
+  { name: "Disable debug logging", description: "Disabled verbose debug logging in production" },
+  { name: "Migrate newsletter vendor", description: "Migrated the newsletter signup to a new vendor" },
+  { name: "Refactor checkout state machine", description: "Refactored the checkout state machine for clarity" },
+  { name: "Add dark mode", description: "Added dark mode support to the settings screen" },
+];
+
+function bestMatch(item) {
+  const vector = localEmbed(embeddingText(item));
+  let best = { name: null, similarity: -Infinity };
+  for (const category of CATEGORIES) {
+    const similarity = cosineSimilarity(vector, localEmbed(embeddingText(category)));
+    if (similarity > best.similarity) best = { name: category.name, similarity };
+  }
+  return best;
+}
+
+test("paraphrases of known categories clear the local threshold at the right category", () => {
+  for (const { expect, ...item } of PARAPHRASES) {
+    const best = bestMatch(item);
+    assert.ok(
+      best.similarity >= DEFAULT_MATCH_THRESHOLDS.local,
+      `"${item.name}" best=${best.name} sim=${best.similarity.toFixed(3)} — below threshold ${DEFAULT_MATCH_THRESHOLDS.local}`,
+    );
+    assert.ok(
+      expect.includes(best.name),
+      `"${item.name}" matched "${best.name}" (sim ${best.similarity.toFixed(3)}), expected one of: ${expect.join(", ")}`,
+    );
+  }
+});
+
+test("novel improvements stay below the local threshold against every category", () => {
+  for (const item of NOVEL) {
+    const best = bestMatch(item);
+    assert.ok(
+      best.similarity < DEFAULT_MATCH_THRESHOLDS.local,
+      `"${item.name}" unexpectedly matched "${best.name}" at sim=${best.similarity.toFixed(3)} (threshold ${DEFAULT_MATCH_THRESHOLDS.local})`,
+    );
+  }
+});

--- a/server/test/server.test.mjs
+++ b/server/test/server.test.mjs
@@ -1,0 +1,178 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createMakefasterServer } from "../server.mjs";
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const quiet = { info() {}, warn() {}, error(msg) { console.error(msg); } };
+
+function listen(server) {
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve(`http://127.0.0.1:${server.address().port}`));
+  });
+}
+
+function close(server) {
+  return new Promise((resolve) => server.close(resolve));
+}
+
+async function withServer(dataDir, fn) {
+  const created = createMakefasterServer({ rootDir: ROOT, dataDir, env: {}, logger: quiet });
+  const base = await listen(created.server);
+  try {
+    await fn(base, created);
+  } finally {
+    await close(created.server);
+  }
+}
+
+test("serves the static marketing pages and live data", async () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "mf-store-"));
+  try {
+    await withServer(dataDir, async (base) => {
+      const index = await fetch(`${base}/`);
+      assert.equal(index.status, 200);
+      assert.match(await index.text(), /npx makefaster/);
+
+      const css = await fetch(`${base}/css/style.css`);
+      assert.equal(css.status, 200);
+      assert.match(css.headers.get("content-type"), /text\/css/);
+
+      const improvements = await (await fetch(`${base}/data/improvements.json`)).json();
+      assert.equal(improvements.length, 50);
+
+      const sites = await (await fetch(`${base}/data/sites.json`)).json();
+      assert.ok(Array.isArray(sites) && sites.length > 0);
+
+      const health = await (await fetch(`${base}/api/health`)).json();
+      assert.equal(health.ok, true);
+      assert.equal(health.embedder, "local-hash-v1");
+
+      const missing = await fetch(`${base}/nope.html`);
+      assert.equal(missing.status, 404);
+
+      const traversal = await fetch(`${base}/..%2f..%2fetc%2fpasswd`);
+      assert.equal(traversal.status, 404);
+    });
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("submit-site inserts then upserts, and persists across restarts", async () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "mf-store-"));
+  const payload = {
+    url: "https://speedy.example.com", mode: "cold",
+    lcpRaw: 1400, lcpDelta: -22, ttiRaw: 2300, ttiDelta: -17,
+  };
+  try {
+    await withServer(dataDir, async (base) => {
+      const first = await fetch(`${base}/api/submit-site`, {
+        method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(payload),
+      });
+      assert.equal(first.status, 201);
+      const firstJson = await first.json();
+      assert.equal(firstJson.created, true);
+      assert.equal(firstJson.row.url, "speedy.example.com");
+      assert.equal(firstJson.row.tests, 1);
+      assert.equal(firstJson.row.favicon, "https://icons.duckduckgo.com/ip3/speedy.example.com.ico");
+
+      const second = await fetch(`${base}/api/submit-site`, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ...payload, lcpRaw: 1300, lcpDelta: -28 }),
+      });
+      assert.equal(second.status, 200);
+      const secondJson = await second.json();
+      assert.equal(secondJson.created, false);
+      assert.equal(secondJson.row.tests, 2);
+      assert.equal(secondJson.row.lcpRaw, 1300);
+
+      const rows = await (await fetch(`${base}/data/sites.json`)).json();
+      const mine = rows.filter((r) => r.url === "speedy.example.com");
+      assert.equal(mine.length, 1);
+
+      const bad = await fetch(`${base}/api/submit-site`, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({ ...payload, mode: "hot" }),
+      });
+      assert.equal(bad.status, 400);
+      assert.match(JSON.stringify(await bad.json()), /mode/);
+    });
+
+    // Restart on the same data dir: the submission must still be there.
+    await withServer(dataDir, async (base) => {
+      const rows = await (await fetch(`${base}/data/sites.json`)).json();
+      const mine = rows.find((r) => r.url === "speedy.example.com" && r.mode === "cold");
+      assert.ok(mine, "row lost across restart");
+      assert.equal(mine.tests, 2);
+    });
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("submit-improvements folds matches and creates novel categories, live table refreshes", async () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "mf-store-"));
+  try {
+    await withServer(dataDir, async (base, { store }) => {
+      const beforeCount = store.getImprovements().find((c) => c.name === "Image Optimization").count;
+      const res = await fetch(`${base}/api/submit-improvements`, {
+        method: "POST", headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          improvements: [
+            { name: "Compress hero images", description: "Compressed and resized the oversized hero images", deltaMs: -420, deltaPct: -19 },
+            { name: "Rewrite ORM in Rust", description: "Rewrote the ORM data layer in Rust", deltaMs: -900, deltaPct: -33 },
+          ],
+        }),
+      });
+      assert.equal(res.status, 200);
+      const json = await res.json();
+      assert.equal(json.ok, true);
+      assert.equal(json.results[0].action, "matched");
+      assert.equal(json.results[0].category, "Image Optimization");
+      assert.equal(json.results[1].action, "created");
+
+      const live = await (await fetch(`${base}/data/improvements.json`)).json();
+      assert.equal(live.length, 51);
+      assert.equal(live.find((c) => c.name === "Image Optimization").count, beforeCount + 1);
+      const created = live.find((c) => c.name === "Rewrite ORM in Rust");
+      assert.ok(created, "novel category missing from live data");
+      assert.equal(created.count, 1);
+      // -33% average puts it at the top of the board
+      assert.equal(created.rank, 1);
+
+      // ranks must be a permutation of 1..51
+      const ranks = live.map((c) => c.rank).sort((a, b) => a - b);
+      assert.deepEqual(ranks, Array.from({ length: 51 }, (_, i) => i + 1));
+
+      // persisted file matches the live response
+      const onDisk = JSON.parse(readFileSync(join(dataDir, "improvements.json"), "utf8"));
+      assert.equal(onDisk.length, 51);
+    });
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});
+
+test("CORS preflight and headers are present for cross-origin static hosting", async () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "mf-store-"));
+  try {
+    await withServer(dataDir, async (base) => {
+      const preflight = await fetch(`${base}/api/submit-site`, { method: "OPTIONS" });
+      assert.equal(preflight.status, 204);
+      assert.equal(preflight.headers.get("access-control-allow-origin"), "*");
+      assert.match(preflight.headers.get("access-control-allow-methods"), /POST/);
+
+      const bad = await fetch(`${base}/api/submit-site`, {
+        method: "POST", headers: { "content-type": "application/json" }, body: "not json",
+      });
+      assert.equal(bad.status, 400);
+      assert.equal(bad.headers.get("access-control-allow-origin"), "*");
+    });
+  } finally {
+    rmSync(dataDir, { recursive: true, force: true });
+  }
+});

--- a/server/test/sites-validate.test.mjs
+++ b/server/test/sites-validate.test.mjs
@@ -1,0 +1,111 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { normalizeSiteUrl, upsertSite, displayNameForUrl, defaultFaviconForUrl } from "../lib/sites.mjs";
+import { validateSitePayload, validateImprovementsPayload } from "../lib/validate.mjs";
+
+test("normalizeSiteUrl accepts common shapes and rejects junk", () => {
+  assert.equal(normalizeSiteUrl("example.com"), "example.com");
+  assert.equal(normalizeSiteUrl("https://Example.com/some/path?q=1"), "example.com");
+  assert.equal(normalizeSiteUrl("www.example.co.uk"), "example.co.uk");
+  assert.equal(normalizeSiteUrl("http://sub.domain.dev"), "sub.domain.dev");
+  assert.equal(normalizeSiteUrl("localhost"), null);
+  assert.equal(normalizeSiteUrl("not a url"), null);
+  assert.equal(normalizeSiteUrl(""), null);
+  assert.equal(normalizeSiteUrl(42), null);
+  assert.equal(normalizeSiteUrl("javascript:alert(1)"), null);
+});
+
+test("displayNameForUrl and defaultFaviconForUrl", () => {
+  assert.equal(displayNameForUrl("docs.example.com"), "Example");
+  assert.equal(displayNameForUrl("jjcm.org"), "Jjcm");
+  assert.equal(defaultFaviconForUrl("example.com"), "https://icons.duckduckgo.com/ip3/example.com.ico");
+});
+
+test("upsertSite inserts a new row with tests=1 and derived name/favicon", () => {
+  const { rows, row, created } = upsertSite([], {
+    url: "example.com", mode: "cold", lcpRaw: 1200, lcpDelta: -20, ttiRaw: 2000, ttiDelta: -15,
+  }, "2026-08-21T00:00:00.000Z");
+  assert.equal(created, true);
+  assert.equal(rows.length, 1);
+  assert.equal(row.tests, 1);
+  assert.equal(row.name, "Example");
+  assert.equal(row.favicon, "https://icons.duckduckgo.com/ip3/example.com.ico");
+  assert.equal(row.measuredAt, "2026-08-21T00:00:00.000Z");
+});
+
+test("upsertSite updates the (url, mode) row, increments tests, keeps other modes", () => {
+  const seed = [
+    { name: "Example", url: "example.com", favicon: "x", lcpRaw: 1500, lcpDelta: -10, ttiRaw: 2500, ttiDelta: -5, mode: "cold", tests: 3, measuredAt: "old" },
+    { name: "Example", url: "example.com", favicon: "x", lcpRaw: 900, lcpDelta: -12, ttiRaw: 1500, ttiDelta: -9, mode: "warm", tests: 3, measuredAt: "old" },
+  ];
+  const { rows, row, created } = upsertSite(seed, {
+    url: "example.com", mode: "cold", lcpRaw: 1100, lcpDelta: -25, ttiRaw: 2100, ttiDelta: -18,
+  }, "2026-08-21T00:00:00.000Z");
+  assert.equal(created, false);
+  assert.equal(rows.length, 2);
+  assert.equal(row.tests, 4);
+  assert.equal(row.lcpRaw, 1100);
+  assert.equal(row.favicon, "x"); // kept from the existing row
+  assert.equal(rows.find((r) => r.mode === "warm").tests, 3); // untouched
+  assert.equal(seed[0].tests, 3); // input not mutated
+});
+
+test("validateSitePayload happy path normalizes and rounds", () => {
+  const result = validateSitePayload({
+    url: "https://Example.com/x", mode: "warm",
+    lcpRaw: 1200.6, lcpDelta: -20.34, ttiRaw: 2000.2, ttiDelta: -15.56,
+    favicon: "https://example.com/favicon.ico", name: "  Example  ",
+  });
+  assert.equal(result.ok, true, JSON.stringify(result.errors));
+  assert.deepEqual(result.value, {
+    url: "example.com", mode: "warm",
+    lcpRaw: 1201, lcpDelta: -20.3, ttiRaw: 2000, ttiDelta: -15.6,
+    favicon: "https://example.com/favicon.ico", name: "Example",
+  });
+});
+
+test("validateSitePayload rejects bad payloads with reasons", () => {
+  for (const [payload, needle] of [
+    [null, "object"],
+    [{ url: "nope", mode: "cold", lcpRaw: 1, lcpDelta: 0, ttiRaw: 1, ttiDelta: 0 }, "url"],
+    [{ url: "example.com", mode: "hot", lcpRaw: 1, lcpDelta: 0, ttiRaw: 1, ttiDelta: 0 }, "mode"],
+    [{ url: "example.com", mode: "cold", lcpRaw: -5, lcpDelta: 0, ttiRaw: 1, ttiDelta: 0 }, "lcpRaw"],
+    [{ url: "example.com", mode: "cold", lcpRaw: 1, lcpDelta: -200, ttiRaw: 1, ttiDelta: 0 }, "lcpDelta"],
+    [{ url: "example.com", mode: "cold", lcpRaw: 1, lcpDelta: 0, ttiRaw: 1, ttiDelta: 0, favicon: "ftp://x" }, "favicon"],
+  ]) {
+    const result = validateSitePayload(payload);
+    assert.equal(result.ok, false);
+    assert.ok(result.errors.some((e) => e.includes(needle)), `expected an error about ${needle}, got: ${result.errors}`);
+  }
+});
+
+test("validateImprovementsPayload happy path trims and strips any url field", () => {
+  const result = validateImprovementsPayload({
+    url: "should-be-discarded.example.com",
+    improvements: [
+      { name: "  Inline critical CSS  ", description: "Inlined above-the-fold styles", deltaMs: -120, deltaPct: -8.5 },
+      { name: "Preload LCP image", deltaPct: -3 },
+    ],
+  });
+  assert.equal(result.ok, true, JSON.stringify(result.errors));
+  assert.equal(result.value.length, 2);
+  assert.equal(result.value[0].name, "Inline critical CSS");
+  assert.equal(result.value[1].description, "");
+  assert.equal(result.value[1].deltaMs, undefined);
+  for (const entry of result.value) assert.equal("url" in entry, false);
+});
+
+test("validateImprovementsPayload rejects bad payloads", () => {
+  for (const [payload, needle] of [
+    [{}, "non-empty array"],
+    [{ improvements: [] }, "non-empty array"],
+    [{ improvements: [{ description: "no name", deltaMs: -1 }] }, "name"],
+    [{ improvements: [{ name: "x", deltaMs: Infinity }] }, "deltaMs"],
+    [{ improvements: [{ name: "x" }] }, "at least one"],
+    [{ improvements: Array.from({ length: 51 }, (_, i) => ({ name: `n${i}`, deltaMs: -1 })) }, "capped"],
+  ]) {
+    const result = validateImprovementsPayload(payload);
+    assert.equal(result.ok, false, `expected rejection: ${JSON.stringify(payload).slice(0, 80)}`);
+    assert.ok(result.errors.some((e) => e.includes(needle)), `expected an error about "${needle}", got: ${result.errors}`);
+  }
+});

--- a/skill/README.md
+++ b/skill/README.md
@@ -1,0 +1,20 @@
+# Canonical speedup skill
+
+`SKILL.md` in this directory is the **canonical, updated version of
+[jjcm/speedupskill](https://github.com/jjcm/speedupskill)'s `SKILL.md`** — the
+measured-technique catalog the makefaster loop draws its hypotheses from.
+
+It lives here because the update could not be opened as a PR against
+`jjcm/speedupskill` from the environment that produced it (no push access to
+that repo). The file is the original document byte-for-byte, plus:
+
+- a new **"Run it as a packaged loop: `npx makefaster`"** section (after the
+  intro), describing CLI detection, the top-50 checklist import, the loop, the
+  5-miss stop rule, and the leaderboard submissions;
+- one added **Sources** entry pointing at this repo.
+
+To sync it upstream, copy `skill/SKILL.md` over `SKILL.md` in
+`jjcm/speedupskill` verbatim.
+
+The *operational* skill that `npx makefaster` hands to the agent is separate:
+[`packages/skill/SKILL.md`](../packages/skill/SKILL.md).

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,204 @@
+---
+name: speedupskill
+description: Use this when speeding up a web or Electron app's load or input. Concrete techniques that moved the needle in measured speed labs (DiffUI boot/LCP, bb large-paste jank) — not generic advice.
+---
+
+# Speed up a web / Electron app
+
+**When to use:** the job is to make a web or Electron app faster to *load* or to *type into* — first content, LCP, TBT, or input latency after a large paste. Not visual polish, not ink/bleed filters, not a drive-by refactor.
+
+**How to work:** measure a user-felt metric first, change one hypothesis per iteration, keep or revert with numbers. Experimental branch stays experimental; a keep/ditch pass (complexity vs speed vs maintainability) happens before anything is proposed for main. See the paste-prompt in `README.md`.
+
+Numbers below are from real labs. Copy the *shape* of the fix, not the file names.
+
+---
+
+## Run it as a packaged loop: `npx makefaster`
+
+This skill's loop discipline is packaged as [makefaster](https://github.com/jjcm/makefaster). Run `npx makefaster` in a site repo and it:
+
+1. detects the agent CLIs already installed (Cursor Agent, Claude Code, Codex — it drives *your* install and never bundles a model) and asks which one should run the loop **before anything starts**;
+2. imports the live top-50 improvement categories from the makefaster leaderboard (`/data/improvements.json`) as a checklist of likely wins — a guide of what has worked across sites, not a script to apply blindly;
+3. profiles a user-felt metric (Lighthouse when available, else the lightest real measurement the machine can produce; cold + warm; median of ≥3 runs, spread = noise floor), then loops exactly as above: one hypothesis per iteration, measure, keep or revert with numbers;
+4. stops after **5 consecutive attempts with no serious improvement** — serious = beats the measured noise floor and moves the north-star metric by ≥5 % or ≥20 ms, and an FCP-only win that regresses LCP does not count — then offers three things: loop more (miss counter resets), submit the site's stats to the public [site leaderboard](https://github.com/jjcm/makefaster) (URL + favicon are displayed), and/or submit anonymous improvements data (category names + deltas only, no URL) that grows the shared checklist for everyone.
+
+The operational loop skill lives at [`packages/skill/SKILL.md`](https://github.com/jjcm/makefaster/blob/main/packages/skill/SKILL.md) in that repo; the document you are reading is its technique catalog — read it when picking hypotheses.
+
+---
+
+## Impact: largest (boot payload and critical JS)
+
+These were the 5–12× wins. Do them before touching images or micro-splits.
+
+### 1. Do not wait on unused workspace data — embed what *this* route needs
+
+DiffUI: every signed-in page sat at ~2.6 s rtt40 / ~15 s slow4g because first paint waited on `/api/me` (queued ~1 s behind module preloads on HTTP/1.1) plus live list fetches after the JS wave.
+
+**What worked**
+
+- Replay the real handlers and embed the responses in the shell HTML as already-resolved fetches (`/api/me`, `/api/workspaces`, first list page, folders/brands for sidebar routes, brand-detail for `/brands/{id}`, team-settings detail for `/teams/settings`).
+- **Server-resolve the active workspace** the same way the client does (cookie → membership → first team) and **scope every boot payload to that workspace**. Personal-scoped embeds silently missed for team-active users; every space route fell back to live fetches until this existed.
+- Deep-link pages (brand detail, team settings) must embed *their* detail payload or content lands a frame after the shell (`LATE_CONTENT`).
+- Path-key drift (query string, page size, order) must degrade to a live fetch, not a wrong payload. Hard-expire the boot map (~20 s) so nothing stale is consumed.
+
+**Attributed**
+
+| change | where | rtt40 cold |
+|---|---|---|
+| embed me + workspaces + first projects page | `/app/projects` grid | 1173 → **471 ms** |
+| embed folders + brands; parallelize sidebar + panel | `/app/brands` | 497 → **383 ms** (pop-in gone) |
+| embed `/api/brands/{id}` | brand detail | 447 → **402 ms** (pop-in gone) |
+| server-resolved workspace + embed team-settings | `/app/teams/settings` | 568 → **443 ms** (warm 218 → **95 ms**) |
+| headline, all kept load work | `/app/projects` | **2642 → 367 ms** (7.2×); brands 2651 → 381; brandDetail 2879 → 398 |
+
+**Do not:** inject every API the app has. Embed the payloads the *current route* will read in the first paint. Extra unused JSON is TTFB and `no-store` HTML weight for nothing.
+
+### 2. Cut the critical JS graph to the first view
+
+DiffUI statically imported 104 modules / **2651 KB** on every route (canvas, yjs, admin, settings). First paint waited on all of it. TBT before content was 54–88 ms.
+
+**What worked**
+
+- Static graph = browse shell only (then 28–34 modules, **147–178 KB** depending on route). Every other view is a route-gated dynamic import; idle-prefetch the rest after the first route settles.
+- **Route-aware `<link rel="modulepreload">`** for the lazy subtree of the URL being served, so deep links are not a serial second wave after `app.js`. Brands/account/billing sat 150–215 ms behind projects until this existed.
+- Split settings by *section* (billing must not download profile/api/usage/referral).
+- Extract whales that only one route runs (`wireAdminPanel` was 52 KB / 27 % of `app.js` — admins on `/app/admin` only).
+- Trim chrome that is not on the first paint (signin modal, coach steps, unused panels).
+
+**Attributed:** lazy split 1391 → 1173 ms rtt40, TBT 94 → 0; route preloads brands 576 → 497; per-section settings account 522 → 401 / billing 569 → 464; admin extract −30…−73 ms slow4g on every route. Warm loads: **zero JS requests** once URLs are content-hashed (next item).
+
+**Do not:** keep splitting once a function-size census says the next cluster is ~3 KB gz and the expected win is below the harness noise floor. DiffUI rejected further `app.js` splits without implementing them — high entanglement, unmeasurable gain.
+
+### 3. Stop the warm 304 storm
+
+Modules were `Cache-Control: no-cache`. Warm load = one revalidation per file = the entire warm cost (projects warm grid **1086 → 144 ms** after hashing, **107 → 0** JS requests).
+
+**What worked:** inject an import map (or equivalent) mapping every module to `?v=<content-hash>`, rewrite preload/script/style URLs the same way, mark matching requests `immutable`. No build step required if the server stats files and hashes are mtime-cached. Deploy flips hashes in the next HTML response — no mixed-version window.
+
+**Tradeoff:** cold pays the map bytes (~+17 ms). Workers/wasm left unversioned stay `no-cache` (correct, unoptimized).
+
+---
+
+## Impact: large (images, LCP, cache)
+
+Do these after boot is no longer waiting on JS/API.
+
+### 4. Serve the rung that matches the CSS slot
+
+Production thumbs were 512 px for ~120 px tiles. Guideline preview loaded a **1600×1200 full board** into a ~550 px box. `srcset` that offered the full board as the only >512 candidate jumped to it at dpr2 (**716 ms / 600 KB**).
+
+**What worked**
+
+- Pipeline `thumbMaxEdge` 512 → **256** (projects LCP 724 → 580 rtt40 / 2312 → 2004 slow4g; **−45 %** cold bytes).
+- 128 px `_thumb_sm` for grid tiles, **lazily materialized** at origin (no backfill). Covers keep 256. Projects LCP 580 → 520; **−238 KB**.
+- Guideline preview = thumb derivative; full-res only in lightbox/download (heavy-asset LCP 732 → 552, −103 KB). Immediate or idle “upgrade to full-res” variants **measured worse** (re-fired LCP / extra bytes) — rejected.
+- `srcset`/`sizes` ladder (128/256/512) for cards, refs, covers, tiles. **Cap the ladder at the slot.** Guideline at 1x stays on the 256 rung (`sizes="256px"`); dpr2 must not jump to the full board (596 ms / 497 KB after the cap).
+- `sizes` is a pinned constant that **must track CSS slot width**. Reused `<img>`s must `removeAttribute("srcset")` when the URL is not a thumb, or `srcset` outranks `src` and shows a stale image.
+
+**Do not:** `<link rel="preload">` the first N grid thumbnails. They steal connections and bandwidth from render-critical JS/CSS (projects grid 480 → **557 ms**; slow4g LCP 2444 → **4028 ms**). Reverted. `fetchpriority=high` on covers was a wash — do not keep unmeasurable behavior changes.
+
+### 5. Immutable / success-only cache for write-once `/files/`
+
+Write-once families (UUID-keyed generation/brand/canvas assets) can be cached. Rewritten-in-place thumbs cannot.
+
+**What worked, after review bugs were found**
+
+- Apply `Cache-Control` in a `ResponseWriter` wrapper at **`WriteHeader` time**, only for **2xx/3xx** (including 206/304). Never set the header before `Serve` — a Stat-vs-GET race or a transient 404/502 will otherwise cache for a year.
+- Canonical rasters (`.png/.jpg/.jpeg`) → `immutable`. Parameter-dependent derivatives (quality, `thumbMaxEdge`) → `max-age=86400`, not immutable — a retune must reach returning visitors.
+- 404s never get the header, so a not-yet-materialized derivative cannot cache a miss.
+
+Lab warm wins for images can be a lie (some headless Chromes never disk-cache `Image`-destination requests). Keep this on first principles; do not claim a warm number you did not measure in production Chrome.
+
+---
+
+## Impact: input path (Electron / editors)
+
+bb composer: pasting a ~1 MB minified-JS line (dense in `` ` `` / `_` / `*` / `/`) froze for seconds and left **~20 ms of pure JS per subsequent keystroke**.
+
+### 6. Large paste: O(n) parse, no full-text rescan per keystroke
+
+| cost at 1 MB | before | after |
+|---|---|---|
+| rich-text Markdown parse (paste/mount/setContent) | **2059 ms** (571 ms @ 512 KB — superlinear) | **11.6 ms** (linear 128 KB–1 MB) |
+| decoration serialize + rule regex, every keystroke | ~8 ms | position-map existing decorations; full rebuild deferred ≤ 200 ms on docs > 10 k chars |
+| typeahead trigger (`textBetween(0, caret)` + regex) | 2.5 ms, twice per keystroke | 256-char window before the caret |
+| value-sync `JSON.stringify` ×2 per keystroke | 3.1 ms each | structural compare, reference equality |
+| draft `JSON.stringify` per keystroke | 3.1 ms | moved into the already-debounced 250 ms persist |
+| thread timeline React re-render per keystroke | yes (subscribed to the draft store for `addQuote` only) | non-subscribing accessor; quote writes at event time |
+
+**What worked**
+
+- Markdown delimiter pairing: sorted-range binary search + monotonic pointer sweeps (**linear**), output byte-identical to the quadratic version.
+- Decorations on large docs: map through the edit; throttle full rebuild. Small docs stay synchronous.
+- Typeahead: windowed scan; disable fake `^` at the window edge.
+- Controlled-value sync: do not stringify the whole text to see if it changed.
+- Draft persist was already debounced — only the serialization belonged inside that window.
+- A parent view that only needs `addQuote` must not subscribe to every draft tick.
+
+**Do not:** blame highlighting, history, or layout first without measuring. History was not on the hot path. Electron layout of a giant wrapped line is a *different* bottleneck and was left unfixed (VM could not measure it). Do not rescan the full document per keystroke for parse, decorations, or triggers. Do not serialize the draft or rerender the thread on every input.
+
+---
+
+## Impact: placeholders (UX, measured price)
+
+ThumbHash is a feature, not a speedup. DiffUI paid **+11–25 ms** rtt40 / **+55–75 ms** slow4g on image routes for ~2.7 KB of hashes + 2 modules. Keep it only if “never a broken-image icon” is the product requirement.
+
+### 7. ThumbHash: average color now, budgeted decode, encode off the GET path
+
+**Do**
+
+1. Paint the hash’s **average color synchronously** (`thumbHashToAverageRGBA` → `background-color`, no PNG). Skip if the img is already complete.
+2. Enqueue full decodes on **one shared queue**. A **single rAF loop** drains it: up to 10 data URLs, yield if >8 ms of the frame is spent (half a 60 fps frame). Stress: 200 pending hashes → 5 frames / 89 ms, **0 long tasks**. Counterfactual: 200 decodes in one block = **42 ms** hitch on a fast VM.
+3. If the real file loads first, dequeue — **never apply a data URL to a loaded img**.
+4. Encode at **derivative write time** (hook the single choke point every webp writer uses). List serving is **SELECT-only** (cold-cache list TTFB 7.8 ms, zero synchronous encodes). History backfills with bounded background workers; the first response simply lacks the hash.
+5. Vendor the decoder on a **tracked** path (`app/lib/…`, not `vendor/`).
+6. Pin the scheduler with a regression test that **fails on burst decode** (fake frame pump + fake clock).
+
+**Do not**
+
+- Ship the decoder under a **gitignored `vendor/`** — clean checkout white-screened; lab numbers ran against an untracked local copy.
+- Encode ThumbHash on the **cold list GET** path.
+- Burst-decode on the main thread (per-image rAF that coalesces into one frame, or one synchronous loop over the grid).
+- Treat this as a load-time win. It is a UX floor with a measured content-time cost. Offset it by lazy-loading the decoder if the cost is unacceptable.
+
+---
+
+## What not to do (lab-proven or out of scope)
+
+| temptation | what actually happened |
+|---|---|
+| Preload first 8 thumbnails | Grid **slower**; slow4g LCP nearly doubled. Images tax the shell on a constrained pipe. |
+| `fetchpriority=high` on covers | Wash. Reverted rather than keep an unmeasurable change. |
+| Cache `/files/` errors / set headers before `WriteHeader` | 404/502 can cache for a year. Success-only, at write time. |
+| `immutable` on WebP derivatives | A `thumbMaxEdge` retune never reaches returning visitors. Bounded `max-age` instead. |
+| `srcset` that includes the full board | dpr2 jumps to 1600w. Cap rungs to the CSS slot. |
+| Immediate or idle upgrade of a preview to full-res | Re-fired LCP and/or extra bytes. Thumb in the box, full-res in lightbox. |
+| ThumbHash decoder in gitignored `vendor/` | Clean checkout white-screens. |
+| Encode hashes on list GET | Synchronous decode+encode on the cold path. Write-time hook + SELECT-only serve. |
+| Burst-decode placeholders | 42 ms hitch at 200 images; TBT spike on real hardware. Budgeted rAF drip. |
+| Further JS splits after the whale is gone | Census: ~15 ms expected, below noise, high entanglement. Reject without implementing. |
+| Quadratic markdown / full-doc regex per keystroke | 2 s paste freeze; ~20 ms JS/keystroke at 1 MB. Linear parse; windowed scans; deferred rebuilds. |
+| `JSON.stringify` draft or re-render thread on every input | 3+ ms × N plus a full timeline render, every character. |
+| SVG `feDisplacementMap` for ink / bleed | **Unrelated.** That is a visual/ink job, not a load or input speed lab. Do not mix it in. |
+| Merge the experimental branch | Lab harnesses, TLS toys, and rejected variants do not belong on main. Keep/ditch first. |
+
+---
+
+## Keep / ditch (before proposing for main)
+
+Score every kept iteration on **speed** (attributed ms), **complexity**, and **maintainability**. A byte win that does not move LCP/TBT is a candidate to ditch.
+
+**Usually take:** workspace-scoped embedded boot payloads; import-map / content-hash immutable JS; route-aware modulepreloads of *this* route only; image ladder matching the CSS slot; success-only `/files/` cache; O(n) paste parse; dropping per-keystroke stringify/rerender.
+
+**Usually ditch this pass (even if “kept” in the lab):** gzip at origin when the CDN already gzips; lazy view-module splits whose LCP is flat; async fonts; deferring billing JS that is not on the first paint of other routes; lab TLS listeners and harnesses; ThumbHash (UX floor, measured *cost* on FCP/LCP — keep only if broken-image flash is the product requirement).
+
+**Take only with pinning tests:** mirrored server/client boot logic (workspace cookie, path keys, preload lists); `sizes` vs CSS; cache headers applied at `WriteHeader` on 2xx/3xx only.
+
+---
+
+## Sources
+
+- DiffUI: [PR #139](https://github.com/jjcm/diffui/pull/139) (`cursor/speed-lab-autoresearch-b738`), `SPEED_LAB.md` iteration inventory. Headline load times are the pre-ThumbHash kept set; ThumbHash is a measured UX add-on (projects ends at 395 / 1455 ms with it).
+- bb: [PR #1](https://github.com/jjcm/bb/pull/1) — composer jank on large minified-JS paste.
+- Infrared (`kaenamiller/infrared`): **pending** — lab still running; no SPEED_LAB.md or PR at draft time.
+- makefaster ([jjcm/makefaster](https://github.com/jjcm/makefaster)): the packaged `npx makefaster` loop, its operational skill, and the community leaderboards this catalog's checklist is imported from.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What this adds

Main already has the marketing site; this PR adds the three working pieces behind it — the site design is untouched.

### 1. `npx makefaster` (`packages/cli/`, zero dependencies)

- **CLI detection the way bb / get-bb does it** — never vendors a model, never starts an inference server; it piggybacks on the agent CLIs already installed:
  - Cursor Agent: `cursor-agent` / bare `agent` (accepted only when it provably is Cursor's — resolved path or `--version` says so), `~/.cursor` home hint, well-known bins;
  - Claude Code: `claude`, honoring `CLAUDE_CODE_EXECUTABLE` / `BB_CLAUDE_CODE_EXECUTABLE`, `~/.local/bin`, `~/.claude/local`, Homebrew paths;
  - Codex: `codex`, `CODEX_HOME`/`~/.codex` hint, npm-global locations.
  - Well-known paths are skipped as root (bb behavior); broken env overrides are surfaced as errors, not silently skipped.
- **Interactive picker before the loop starts** (raw readline, arrows/jk/numbers; `--cli` skips it; single-found confirms; non-TTY degrades with instructions). None found → real installers printed (cursor.com/install, claude.ai/install.sh, `npm i -g @openai/codex`) in bb's missing-CLI tone, exit 1.
- **Imports the top-50 checklist** from the live board (`<api>/data/improvements.json`) → GitHub raw → the target repo's copy → packaged fallback.
- **Hands the repo to the chosen agent** with the loop skill, then owns the **end screen**: session summary + the three questions — *Loop more?* (miss counter resets, agent re-invoked), *Submit stats to the Site leaderboard?* (explicit "URL/favicon will be public" notice), *Submit anonymous improvements?* (no URL by construction). Failed submits are saved to `.makefaster/pending-submissions.json`.
- Session contract lives in `.makefaster/` (auto-added to `.git/info/exclude`).

### 2. The skills

- **`packages/skill/SKILL.md`** — the operational makefaster loop: profile (Lighthouse → Playwright/Puppeteer → curl-level fallback; cold+warm; median of ≥3; recorded noise floor), one hypothesis per iteration, keep/revert bar (serious = beats noise floor and ≥5% or ≥20 ms on the north star; FCP-only wins that regress LCP don't count), the 5-consecutive-miss stop rule, and the exact `results.json` schema the CLI consumes.
- **`skill/SKILL.md`** — the canonical **updated jjcm/speedupskill catalog**: byte-exact original plus a "Run it as a packaged loop: `npx makefaster`" section and one Sources entry. It lives here because this environment has **no push access to jjcm/speedupskill** (all repo permissions came back false), so the separate PR on that repo could not be opened; `skill/README.md` documents this and how to sync it upstream verbatim.

### 3. Real submit APIs (`server/`, zero dependencies)

`node server/server.mjs` (localhost:8787) serves the static site, **live** `GET /data/sites.json` + `GET /data/improvements.json` from a seeded atomic JSON store, and:

- **`POST /api/submit-site`** `{ url, favicon?, name?, lcpRaw, lcpDelta, ttiRaw, ttiDelta, mode: cold|warm }` — validated + normalized, upsert per `(url, mode)`, `tests` counter increments, favicon derived when missing.
- **`POST /api/submit-improvements`** `{ improvements: [{ name, description, deltaMs, deltaPct }] }` — anonymous by construction (any `url` field is discarded). Each entry is **embedded and cosine-matched** against every current category: above threshold → count increments and deltas fold into the running averages; below → a **new category is created** on the improvement leaderboard. Ranks recompute and persist so the HTML tables refresh.
- **Embeddings without a GPU**: a deterministic local feature-hashing embedder (stemmed words + bigrams + char n-grams, 4096 dims) by default; optional documented OpenAI-compatible backend via `OPENAI_API_KEY`/`MAKEFASTER_EMBEDDINGS_*`. Nothing is persisted in embedding space, so backends are freely switchable. The local match threshold (0.3) is pinned by paraphrase/novel separation tests (min positive 0.384 vs max novel 0.138 on a 22-case corpus).
- CORS, 256 KB body cap, 60 POSTs/min/IP, atomic temp-file+rename persistence. Deploy docs in `server/README.md` (env vars, systemd unit, static-pages-elsewhere via `window.MAKEFASTER_API_BASE`).

### 4. Site wiring (no redesign)

`js/api.js` localStorage stubs → real `fetch` POSTs with the same `MakefasterAPI` wrapper signatures. Marketing pages still work under `python3 -m http.server` (they only read the committed JSON; live tables appear behind the Node server).

## Verification

- `npm test` — 47 tests: CLI detection (fake bins/homes/env overrides/root/`agent` disambiguation), args, payload builders, checklist import (hermetic HTTP), embedding separation, categorize fold/create/rerank, HTTP API end-to-end incl. persistence across restart and traversal guard.
- Manual E2E: server curl flows, `python3 -m http.server` page checks, full tmux-driven `npx makefaster` run with a fake agent CLI (picker → handoff → end screen → both submissions landing on the local board), `npm pack` contents.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2ae01278-d991-4324-b00e-385856a6c24b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2ae01278-d991-4324-b00e-385856a6c24b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

