### PR TITLE
Plot every measured iteration, and require the numbers to be in results.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,17 @@ no dependencies — raw ANSI, three panels, repainted from
 - **AUTORESEARCH / WEBSITE SPEED** — the loop counter, the current experiment,
   and every metric the session measured (`lcpMs`, `tbtMs`, `fcpMs`, `ttiMs`,
   plus `cls` and `score` when the agent records them) as candidate vs baseline.
-  Rows for metrics you did not measure are left out rather than shown empty.
+  Rows for metrics you did not measure are left out rather than shown empty. The
+  candidate is `results.final` once the last measurement pass has been written,
+  and until then it is the state the kept iterations have walked the site to —
+  so a keep moves the column the moment it is recorded.
 - **RUN TIMINGS** — one bar per run on the north-star metric, with a dashed
-  baseline, a star on the best run, and the rolling average. The schema stores
-  per-iteration deltas rather than absolutes, so the bars are the baseline
-  walked forward through the deltas — kept iterations move the running value,
-  reverted ones do not.
+  baseline, a star on the best run, and the rolling average. Every measured
+  iteration is a bar, kept or reverted: a miss was profiled just as carefully,
+  and only kept ones move the running value. An iteration can report either the
+  absolute value the run landed on or the `deltaMs` it moved, and one that
+  reports neither is a row the agent has not filled in yet — so it gets no bar
+  rather than a guessed one. Skips are not runs and never appear.
 
 `q` or Ctrl-C stops the round and restores the terminal; a resize re-renders.
 The dashboard needs a TTY on both stdin and stdout — when output is piped, or

--- a/packages/cli/lib/dashboard.js
+++ b/packages/cli/lib/dashboard.js
@@ -9,10 +9,15 @@
  *
  * Everything is derived from `.makefaster/results.json` (the contract in
  * packages/skill/SKILL.md) plus the log the hidden agent's event stream feeds.
- * The schema carries per-iteration deltas rather than per-iteration absolutes,
- * so run values are reconstructed by walking the deltas from the baseline —
- * which is exactly what `deltaMs` means: the change against the previous kept
- * state.
+ * An iteration may report its measurement either way round: an absolute
+ * north-star value for the run, or the `deltaMs` it moved against the previous
+ * kept state. Absolutes win when both are present, and a run reported only as a
+ * delta is reconstructed by walking the deltas forward from the baseline.
+ *
+ * Every measured iteration is a run, kept or reverted — a miss was profiled too,
+ * and hiding it would make the chart a highlight reel. What is not a run is an
+ * iteration carrying no measurement at all: a skip, or a stub the agent has not
+ * filled in yet.
  */
 
 import { BLOCKS, BLOCK_FULL, BOX, COLORS, STAR, fit, formatDuration, seg } from "./theme.js";
@@ -60,11 +65,17 @@ function formatMetric(metric, value) {
 /**
  * Candidate vs baseline per metric, with the signed change. `better` is the
  * direction that matters for that metric, not the sign of the number.
+ *
+ * `results.final` is the last full measurement pass and is authoritative once it
+ * exists — but it is written at the end of the run, so mid-run the candidate is
+ * the state the kept iterations have walked the site to. Without that fallback
+ * the column sits on the baseline at 0% for the whole session, which reads as
+ * "nothing has worked" rather than "the final pass has not run yet".
  */
 export function deriveMetrics(results) {
   const mode = pickMode(results);
   const baseline = results?.baseline?.[mode] ?? null;
-  const candidate = results?.final?.[mode] ?? baseline;
+  const candidate = results?.final?.[mode] ?? deriveRuns(results).candidate?.metrics ?? baseline;
   return METRICS.flatMap((metric) => {
     const base = baseline?.[metric.key];
     const now = candidate?.[metric.key];
@@ -93,47 +104,138 @@ function changeLabel(metric, change, raw) {
   return `${rounded > 0 ? "+" : ""}${rounded}%`;
 }
 
+/** A skip costs no measurement, so it is never a run and never gets a bar. */
+function isSkipped(iteration) {
+  return iteration?.skipped === true || String(iteration?.kept ?? "").toLowerCase() === "skipped";
+}
+
+/** The absolute metric values an object carries, ignoring everything else on it. */
+function metricValues(source) {
+  if (!source || typeof source !== "object") return null;
+  let values = null;
+  for (const metric of METRICS) {
+    if (!Number.isFinite(source[metric.key])) continue;
+    values ??= {};
+    values[metric.key] = source[metric.key];
+  }
+  return values;
+}
+
 /**
- * One bar per run: the baseline, then every measured iteration. Iteration
- * values are the baseline walked forward through the deltas — kept iterations
- * move the running value, reverted ones do not.
+ * The absolute measurement an iteration recorded, if it recorded one. The schema
+ * asks for `measured.<mode>`, but an agent that writes the same numbers flat, or
+ * straight under the mode, has still measured the run — and a real measurement
+ * is not worth throwing away over the shape it arrived in. Later sources are
+ * more specific, so they win.
+ */
+function iterationMeasurement(iteration, mode) {
+  if (!iteration || typeof iteration !== "object") return null;
+  const sources = [iteration, iteration.after, iteration.measured, iteration[mode], iteration.after?.[mode], iteration.measured?.[mode]];
+  let values = null;
+  for (const source of sources) {
+    const found = metricValues(source);
+    if (found) values = { ...values, ...found };
+  }
+  return values;
+}
+
+/**
+ * Every iteration that carries a real measurement, in file order, each with the
+ * north-star value it landed on, the delta it moved from the state before it,
+ * and the metric snapshot the site was in when it was measured.
+ *
+ * An iteration is measured when it has an absolute north-star value or a finite
+ * delta — the two honest ways of saying "this was tested". Both keeps and misses
+ * qualify: a reverted experiment was profiled just as carefully as a kept one.
+ * An iteration with neither is a stub the agent has not filled in yet, and a
+ * stub is not a result — it gets no bar, no verdict and no RESULT line.
+ */
+export function measuredIterations(results) {
+  const mode = pickMode(results);
+  const key = northStarKey(results);
+  const baseline = results?.baseline?.[mode] ?? null;
+  let running = Number.isFinite(baseline?.[key]) ? baseline[key] : null;
+  let runningMetrics = metricValues(baseline) ?? {};
+  const measured = [];
+
+  for (const [position, iteration] of (results?.iterations ?? []).entries()) {
+    if (!iteration || isSkipped(iteration)) continue;
+    const values = iterationMeasurement(iteration, mode);
+
+    let value = null;
+    if (Number.isFinite(values?.[key])) value = values[key];
+    else if (Number.isFinite(iteration.deltaMs) && running !== null) value = running + iteration.deltaMs;
+    else if (Number.isFinite(iteration.deltaPct) && running !== null) value = running * (1 + iteration.deltaPct / 100);
+
+    // An absolute is measured against the state it was run from, so it produces
+    // its own delta; a delta with no baseline to anchor it is still a number the
+    // agent measured, even though there is nothing to plot it against.
+    const deltaMs = value !== null && running !== null ? value - running
+      : Number.isFinite(iteration.deltaMs) ? iteration.deltaMs
+      : null;
+    if (value === null && deltaMs === null) continue;
+
+    const deltaPct = Number.isFinite(iteration.deltaPct) ? iteration.deltaPct
+      : deltaMs !== null && running ? (deltaMs / running) * 100
+      : null;
+    const index = Number.isFinite(iteration.n) ? iteration.n : position + 1;
+    const kept = iteration.kept === true;
+    const metrics = { ...runningMetrics, ...values, ...(value === null ? null : { [key]: value }) };
+
+    measured.push({ iteration, position, index, name: iteration.name || `iteration ${index}`, value, deltaMs, deltaPct, kept, metrics });
+    // Only a keep moves the site; a revert put everything back where it was.
+    if (kept && value !== null) {
+      running = value;
+      runningMetrics = metrics;
+    }
+  }
+  return measured;
+}
+
+/**
+ * One bar per run: the baseline, then every measured iteration — keeps and
+ * misses alike. `candidate` is the run the site currently stands at, which is
+ * the last kept run, or the baseline when nothing has been kept yet.
  */
 export function deriveRuns(results) {
   const mode = pickMode(results);
   const key = northStarKey(results);
-  const baselineValue = results?.baseline?.[mode]?.[key];
-  if (!Number.isFinite(baselineValue)) return { baseline: null, runs: [], best: null, key };
+  const baselineMetrics = results?.baseline?.[mode] ?? null;
+  const baselineValue = baselineMetrics?.[key];
+  if (!Number.isFinite(baselineValue)) return { baseline: null, runs: [], best: null, key, candidate: null };
 
-  const runs = [{ index: 0, label: "000", value: baselineValue, kept: true, name: "baseline", isBaseline: true }];
-  let running = baselineValue;
-  for (const [i, iteration] of (results?.iterations ?? []).entries()) {
-    if (!Number.isFinite(iteration?.deltaMs)) continue; // unmeasured: nothing honest to plot
-    const value = running + iteration.deltaMs;
-    const index = Number.isFinite(iteration.n) ? iteration.n : i + 1;
+  const runs = [{
+    index: 0, label: "000", value: baselineValue, kept: true, name: "baseline",
+    isBaseline: true, deltaMs: 0, metrics: metricValues(baselineMetrics) ?? {},
+  }];
+  for (const entry of measuredIterations(results)) {
+    if (!Number.isFinite(entry.value)) continue;
     runs.push({
-      index,
-      label: String(index).padStart(3, "0"),
-      value,
-      kept: iteration.kept === true,
-      name: iteration.name || `iteration ${index}`,
+      index: entry.index,
+      label: String(entry.index).padStart(3, "0"),
+      value: entry.value,
+      kept: entry.kept,
+      name: entry.name,
       isBaseline: false,
+      deltaMs: entry.deltaMs,
+      metrics: entry.metrics,
     });
-    if (iteration.kept === true) running = value;
   }
 
   const best = runs.reduce((low, run) => (low === null || run.value < low.value ? run : low), null);
-  return { baseline: baselineValue, runs, best, key };
+  const candidate = runs.findLast((run) => run.kept) ?? runs[0];
+  return { baseline: baselineValue, runs, best, key, candidate };
 }
 
 /** IMPROVED / REGRESSED / UNCHANGED for the most recent measured iteration. */
 export function deriveVerdict(results) {
-  const iterations = (results?.iterations ?? []).filter((it) => Number.isFinite(it?.deltaMs));
-  const latest = iterations.at(-1);
-  if (!latest) return { label: "PENDING", better: null, iteration: null };
-  const noiseFloor = results?.noiseFloor?.lcpMs ?? 0;
-  if (Math.abs(latest.deltaMs) <= noiseFloor) return { label: "UNCHANGED", better: null, iteration: latest };
-  if (latest.deltaMs < 0) return { label: "IMPROVED", better: true, iteration: latest };
-  return { label: "REGRESSED", better: false, iteration: latest };
+  const latest = measuredIterations(results).at(-1);
+  const of = (label, better) => ({ label, better, iteration: latest?.iteration ?? null, name: latest?.name ?? null });
+  if (!latest || !Number.isFinite(latest.deltaMs)) return of("PENDING", null);
+  const noiseFloor = results?.noiseFloor?.[northStarKey(results)] ?? results?.noiseFloor?.lcpMs ?? 0;
+  if (Math.abs(latest.deltaMs) <= noiseFloor) return of("UNCHANGED", null);
+  if (latest.deltaMs < 0) return of("IMPROVED", true);
+  return of("REGRESSED", false);
 }
 
 function experimentId(index) {
@@ -223,7 +325,7 @@ function autoresearchPanel({ width, height, results, state, status, updatedAt })
   const verdict = deriveVerdict(results);
   const metrics = deriveMetrics(results);
   const loop = Math.max(0, runs.runs.length - 1);
-  const currentExperiment = verdict.iteration?.name || (results ? "measuring baseline" : "starting up");
+  const currentExperiment = verdict.name || (results ? "measuring baseline" : "starting up");
 
   // Below roughly 100 columns the side-by-side table cannot hold its own
   // columns, and the left metrics already carry candidate, baseline and Δ — so
@@ -249,7 +351,9 @@ function autoresearchPanel({ width, height, results, state, status, updatedAt })
   if (!showTable) {
     body.push(...(left.length > 0 ? left : [[seg("waiting for the first measurement", "muted")]]));
   } else {
-    const right = comparisonRows({ metrics, width: tableWidth, candidateIndex: verdict.iteration ? loop : 0 });
+    // The candidate column is whatever run the site currently stands at, so it
+    // names the last kept experiment rather than the last one attempted.
+    const right = comparisonRows({ metrics, width: tableWidth, candidateIndex: runs.candidate?.index ?? 0 });
     for (let i = 0; i < Math.max(left.length, right.length); i++) {
       const row = left[i] ?? [];
       body.push([

--- a/packages/cli/lib/loopView.js
+++ b/packages/cli/lib/loopView.js
@@ -17,6 +17,7 @@
  * it in the panel drowned the two lines a reader actually wanted.
  */
 
+import { measuredIterations } from "./dashboard.js";
 import { watchResults } from "./resultsWatch.js";
 import { watchStepLog } from "./stepLog.js";
 
@@ -49,7 +50,10 @@ export function createLoopView({ tui, paths, state, provider, model, now = () =>
   let results = null;
   let updatedAt = null;
   let status = "RUNNING";
-  let seenIterations = 0;
+  // Keyed by position in `iterations`, not by how many have been seen: an agent
+  // that writes the row first and fills in the numbers on the next write must
+  // still get its one RESULT line when the numbers land.
+  const announced = new Set();
   let announcedBaseline = false;
   let eventCount = 0;
   let lastLabel = null;
@@ -82,23 +86,26 @@ export function createLoopView({ tui, paths, state, provider, model, now = () =>
       append("TEST", `Baseline measured (${mode})${Number.isFinite(lcp) ? `: LCP ${Math.round(lcp)}ms` : ""}`);
     }
 
-    const iterations = Array.isArray(next?.iterations) ? next.iterations : [];
-    for (const iteration of iterations.slice(seenIterations)) {
-      // One line per iteration, and it names the experiment: the agent has
-      // usually already reported `[TRY] <name>`, so repeating that would be a
-      // second row saying nothing new — but this line still stands alone for an
-      // agent that reports nothing at all.
+    // One line per measured iteration, and it names the experiment: the agent
+    // has usually already reported `[TRY] <name>`, so repeating that would be a
+    // second row saying nothing new — but this line still stands alone for an
+    // agent that reports nothing at all.
+    //
+    // Only measured iterations. A row with no numbers on it has not produced a
+    // result yet, and announcing one as `no delta recorded — reverted` reports a
+    // miss the agent never measured.
+    const star = next?.northStar || "lcp";
+    for (const entry of measuredIterations(next)) {
+      if (announced.has(entry.position)) continue;
+      announced.add(entry.position);
       const parts = [
-        Number.isFinite(iteration?.deltaMs) ? signedMs(iteration.deltaMs) : null,
-        Number.isFinite(iteration?.deltaPct) ? signedPct(iteration.deltaPct) : null,
+        Number.isFinite(entry.deltaMs) ? signedMs(entry.deltaMs) : null,
+        Number.isFinite(entry.deltaPct) ? signedPct(entry.deltaPct) : null,
       ].filter(Boolean);
-      const measured = parts.length > 0
-        ? `${parts.join(" / ")} on ${next?.northStar || "lcp"}`
-        : "no delta recorded";
-      const verdict = iteration?.kept === true ? "kept" : "reverted, did not beat the noise floor";
-      append("RESULT", `${iteration?.name || "Unnamed experiment"}: ${measured} — ${verdict}`);
+      const measured = parts.length > 0 ? `${parts.join(" / ")} on ${star}` : `${star} ${Math.round(entry.value)}ms`;
+      const verdict = entry.kept ? "kept" : "reverted, did not beat the noise floor";
+      append("RESULT", `${entry.name}: ${measured} — ${verdict}`);
     }
-    seenIterations = iterations.length;
     render();
   }
 

--- a/packages/cli/test/dashboard.test.mjs
+++ b/packages/cli/test/dashboard.test.mjs
@@ -76,6 +76,100 @@ test("deriveRuns skips unmeasured iterations rather than plotting a guess", () =
   assert.deepEqual(runs.map((r) => r.value), [1000, 900]);
 });
 
+// The whole point of the chart: a measured iteration is a run whatever the
+// verdict was. A run that only appears when it wins is a highlight reel.
+test("a keep adds a bar and moves the candidate off the baseline", () => {
+  const results = {
+    northStar: "lcp",
+    baseline: { warm: { lcpMs: 4658, ttiMs: 6000 } },
+    iterations: [{ n: 1, name: "Defer non-critical scripts", deltaMs: -1050, deltaPct: -22.5, kept: true }],
+  };
+  const { runs, candidate, best } = deriveRuns(results);
+  assert.deepEqual(runs.map((r) => r.value), [4658, 3608]);
+  assert.equal(candidate.index, 1);
+  assert.equal(candidate.metrics.lcpMs, 3608);
+  assert.equal(best.label, "001");
+
+  // No results.final yet — mid-run the candidate column is where the keeps have
+  // walked the site to, not the baseline sitting at 0%.
+  const lcp = deriveMetrics(results).find((m) => m.short === "LCP");
+  assert.equal(lcp.candidate, "3.61 s");
+  assert.equal(lcp.baseline, "4.66 s");
+  assert.equal(lcp.changeLabel, "-22.5%");
+  assert.equal(lcp.better, true);
+  assert.equal(deriveVerdict(results).label, "IMPROVED");
+});
+
+test("a reverted miss still gets a bar, and does not move the candidate", () => {
+  const results = {
+    northStar: "lcp",
+    baseline: { cold: { lcpMs: 2000 } },
+    iterations: [
+      { n: 1, name: "Preload LCP image", deltaMs: 210, deltaPct: 10.5, kept: false },
+      { n: 2, name: "Enable gzip", deltaMs: -300, deltaPct: -15, kept: true },
+      { n: 3, name: "Inline critical CSS", deltaMs: 40, deltaPct: 2.4, kept: false },
+    ],
+  };
+  const { runs, candidate } = deriveRuns(results);
+  assert.deepEqual(runs.map((r) => r.value), [2000, 2210, 1700, 1740]);
+  assert.deepEqual(runs.map((r) => r.kept), [true, false, true, false]);
+  // The last run is a miss, so the site still stands at the last keep.
+  assert.equal(candidate.index, 2);
+  assert.equal(candidate.metrics.lcpMs, 1700);
+});
+
+test("an iteration that reports where it landed is plotted without a delta", () => {
+  const results = {
+    northStar: "lcp",
+    baseline: { warm: { lcpMs: 4658, ttiMs: 6000 } },
+    iterations: [{ n: 1, name: "Defer non-critical scripts", kept: true, measured: { warm: { lcpMs: 3608, ttiMs: 5200 } } }],
+  };
+  const { runs, candidate } = deriveRuns(results);
+  assert.deepEqual(runs.map((r) => r.value), [4658, 3608]);
+  // The delta is the measurement against the state it ran from, so the verdict
+  // and the RESULT line still have a number to quote.
+  assert.equal(runs[1].deltaMs, -1050);
+  assert.equal(deriveVerdict(results).label, "IMPROVED");
+  assert.equal(candidate.metrics.ttiMs, 5200);
+  assert.equal(deriveMetrics(results).find((m) => m.short === "TTI").candidate, "5.20 s");
+});
+
+// An absolute wins over a delta, because it is the number that was measured
+// rather than one derived from a running total.
+test("an absolute north-star value is trusted over a stale delta", () => {
+  const { runs } = deriveRuns({
+    baseline: { cold: { lcpMs: 2000 } },
+    iterations: [{ n: 1, name: "x", deltaMs: -1, kept: true, measured: { cold: { lcpMs: 1500 } } }],
+  });
+  assert.deepEqual(runs.map((r) => r.value), [2000, 1500]);
+  assert.equal(runs[1].deltaMs, -500);
+});
+
+test("a stub with no numbers is not a run, a verdict, or a candidate", () => {
+  const results = {
+    northStar: "lcp",
+    baseline: { cold: { lcpMs: 2000, ttiMs: 3000 } },
+    iterations: [{ kept: false }, { n: 2, kept: true }],
+  };
+  const { runs, candidate } = deriveRuns(results);
+  assert.deepEqual(runs.map((r) => r.value), [2000], "an unfilled row has nothing to plot");
+  assert.equal(candidate.isBaseline, true);
+  assert.equal(deriveVerdict(results).label, "PENDING");
+  assert.deepEqual(deriveMetrics(results).map((m) => m.changeLabel), ["0%", "0%"]);
+});
+
+test("a skip never gets a bar, even when it was written into iterations", () => {
+  const { runs } = deriveRuns({
+    baseline: { cold: { lcpMs: 2000 } },
+    iterations: [
+      { n: 1, name: "Enable gzip", skipped: true, measured: { cold: { lcpMs: 2000 } } },
+      { n: 2, name: "Lazy-load components", kept: "skipped", deltaMs: 0 },
+      { n: 3, name: "Inline critical CSS", deltaMs: -120, kept: true },
+    ],
+  });
+  assert.deepEqual(runs.map((r) => r.label), ["000", "003"]);
+});
+
 test("deriveRuns needs a baseline before it will plot anything", () => {
   assert.deepEqual(deriveRuns(null).runs, []);
   assert.deepEqual(deriveRuns({ iterations: [{ deltaMs: -10 }] }).runs, []);
@@ -161,6 +255,33 @@ test("buildDashboard renders all three panels with their real numbers", () => {
   assert.match(frame, /ROLLING AVERAGE \(last 5 runs\)/);
   assert.match(frame, /TOTAL RUNS: 4/);
   assert.match(frame, /IMPROVEMENT vs BASELINE: -30\.6%/);
+});
+
+// Mid-run, before results.final exists: the panels must have moved off the
+// baseline, or the user reads a working loop as a stalled one.
+test("buildDashboard advances the loop and the candidate before final is written", () => {
+  const frame = text(buildDashboard({
+    size: { columns: 120, rows: 44 },
+    results: {
+      northStar: "lcp",
+      noiseFloor: { lcpMs: 40 },
+      baseline: { warm: { lcpMs: 4658 } },
+      iterations: [
+        { n: 1, name: "Preload LCP image", deltaMs: 210, deltaPct: 4.5, kept: false },
+        { n: 2, name: "Defer non-critical scripts", deltaMs: -1050, deltaPct: -22.5, kept: true },
+      ],
+    },
+    log: [],
+  }));
+
+  assert.match(frame, /LOOP 002/);
+  assert.match(frame, /CURRENT EXPERIMENT: Defer non-critical scripts/);
+  assert.match(frame, /RESULT: IMPROVED/);
+  assert.match(frame, /exp_002/, "the candidate column names the last kept run");
+  assert.match(frame, /PAGE LOAD TIME \(LCP\)\s+3\.61 s\s+4\.66 s\s+-22\.5%/);
+  assert.match(frame, /TOTAL RUNS: 3/, "baseline, the miss, and the keep");
+  assert.match(frame, /3608/);
+  assert.match(frame, /4868/);
 });
 
 test("buildDashboard survives an empty session and a half-written file", () => {

--- a/packages/cli/test/loopview.test.mjs
+++ b/packages/cli/test/loopview.test.mjs
@@ -197,6 +197,50 @@ test("a new results.json iteration produces exactly one RESULT line", () => {
   view.stop();
 });
 
+// `Unnamed experiment: no delta recorded — reverted` was the panel reporting a
+// miss the agent never measured, off a row it had not filled in yet.
+test("a row with no numbers on it is not reported as a result", () => {
+  const paths = session();
+  paths.write({ version: 1, northStar: "lcp", baseline: { warm: { lcpMs: 4658 } }, iterations: [] });
+  const { view } = harness(paths);
+
+  paths.write({
+    version: 1, northStar: "lcp",
+    baseline: { warm: { lcpMs: 4658 } },
+    iterations: [{ kept: true }],
+  });
+  view.flush();
+  assert.deepEqual(view.log.filter((e) => e.tag === "RESULT"), []);
+
+  // The same row, once the measurement lands, is a result — announced once.
+  paths.write({
+    version: 1, northStar: "lcp",
+    baseline: { warm: { lcpMs: 4658 } },
+    iterations: [{ n: 1, name: "Defer non-critical scripts", deltaMs: -1050, deltaPct: -22.5, kept: true }],
+  });
+  view.flush();
+  view.flush();
+  assert.deepEqual(view.log.filter((e) => e.tag === "RESULT").map((e) => e.text), [
+    "Defer non-critical scripts: -1050ms / -22.5% on lcp — kept",
+  ]);
+  view.stop();
+});
+
+test("an iteration that reports only where it landed still gets its RESULT line", () => {
+  const paths = session();
+  paths.write({
+    version: 1, northStar: "lcp",
+    baseline: { warm: { lcpMs: 4658 } },
+    iterations: [{ n: 1, name: "Defer non-critical scripts", kept: true, measured: { warm: { lcpMs: 3608 } } }],
+  });
+  const { view } = harness(paths);
+
+  assert.deepEqual(view.log.filter((e) => e.tag === "RESULT").map((e) => e.text), [
+    "Defer non-critical scripts: -1050ms / -22.5% on lcp — kept",
+  ]);
+  view.stop();
+});
+
 test("setStatus is reflected in the next frame", () => {
   const paths = session();
   const { view, last } = harness(paths);

--- a/packages/skill/SKILL.md
+++ b/packages/skill/SKILL.md
@@ -84,6 +84,11 @@ The dashboard adds the measured numbers itself, straight from `results.json`, so
 you do not need to report them twice — but a `[RESULT]` line of your own is
 welcome and is what a reader looks for.
 
+It can only do that if the numbers are in the file. A `[RESULT]` line is a
+sentence in a log: nothing reads it for a value, and no chart moves because of
+it. Writing the deltas here and not into `results.json` leaves the user watching
+a run whose log fills up while every number stays on the baseline.
+
 ## Step 0 — get the site running
 
 Work out how this site is served (README, `package.json` scripts, Makefile,
@@ -178,6 +183,41 @@ where it leads instead of following.
 **Update `results.json` and `state.json` after every iteration.** Keep
 `results.json` valid JSON at all times — the CLI parses it the moment you exit,
 even if you were interrupted.
+
+### Every measurement is a row with numbers in it
+
+`results.json` is the only source of numbers the dashboard has. Your
+`[RESULT]` line is prose in a log — the CLI cannot chart it, and will not try.
+So **the moment a `[TEST]` finishes, rewrite `results.json`** with the row that
+test produced:
+
+- a **generic `name`** (never blank), `description`, `category`, `notes`;
+- **`deltaMs` and `deltaPct`** — the measured north-star change against the
+  previous kept state, negative when the site got faster;
+- **`measured`** — the absolute medians that run produced, per mode, in the same
+  shape as `baseline`. This is what makes the row plottable even if a delta is
+  wrong or missing;
+- **`kept`** — `true` or `false`, never absent;
+- **`generic`** on every keep.
+
+Then, on a keep, **also refresh `results.final`** for the modes you measured so
+the candidate column tracks the site as it stands now. `final` is re-measured
+properly one last time before you exit, but leaving it at the baseline all run
+tells the user that nothing has worked yet.
+
+Two rules this exists to prevent, both of which silently freeze the user's
+dashboard on the baseline for the whole session:
+
+- **Never append a row with no numbers on it** — no `{"kept": true}` stubs, no
+  unnamed rows, no "I will fill in the deltas later". A row with neither a delta
+  nor an absolute is not a result, and the CLI treats it as one that has not
+  happened yet: no bar, no verdict, no `[RESULT]` line.
+- **A miss is a row too.** Every non-skipped test gets one, kept or reverted —
+  you profiled the reverted experiment just as carefully, and its bar is how the
+  user sees that the loop is working rather than stalled.
+
+A **`[SKIP]` is not a test**: it costs no measurement, so it gets no row in
+`iterations[]` and no bar. Report it and move on.
 
 ## Naming and describing an improvement — generic techniques only
 
@@ -405,6 +445,7 @@ milliseconds. Deltas are negative when the site got faster.
       "category": "Inline Critical CSS",
       "notes": "Extracted the 4.1KB of rules the hero uses out of app.css into <style> in index.html",
       "generic": true,
+      "measured": { "cold": { "lcpMs": 2140, "ttiMs": 3700 } },
       "deltaMs": -260,
       "deltaPct": -10.8,
       "kept": true
@@ -416,6 +457,7 @@ milliseconds. Deltas are negative when the site got faster.
       "category": null,
       "notes": "The session spinner blocked the homepage until the feature-flag SDK resolved",
       "generic": false,
+      "measured": { "cold": { "lcpMs": 1730, "ttiMs": 3200 } },
       "deltaMs": -410,
       "deltaPct": -14.2,
       "kept": true
@@ -426,6 +468,7 @@ milliseconds. Deltas are negative when the site got faster.
       "description": "Preload the image the largest contentful paint waits on",
       "category": "Preload LCP Image",
       "notes": "Added <link rel=preload> for the first 8 grid thumbnails; LCP regressed, reverted",
+      "measured": { "cold": { "lcpMs": 1880, "ttiMs": 3350 } },
       "deltaMs": 150,
       "deltaPct": 6.2,
       "kept": false
@@ -457,7 +500,13 @@ Field notes:
   leaderboard), `fcpMs` / `tbtMs` / `cls` / `score` (0-100 performance score)
   are welcome extras — the CLI's live dashboard shows a row per metric you
   supply and omits the rest. `final` for a mode is the last full measurement
-  pass, re-run after the last kept change.
+  pass, re-run after the last kept change — refresh it after every keep as you
+  go, and re-measure it properly before you exit.
+- `iterations[].measured` — the absolute medians that iteration's test produced,
+  per mode, in the same shape as `baseline`. Required on every measured
+  iteration: the deltas say how far the site moved, and this says where it
+  landed, which is what the dashboard plots. It is recorded for reverts too —
+  the number was measured before you put the code back.
 - `iterations[].category` — the checklist category name this corresponds to,
   or `null` when it is genuinely novel (the server will embed the name +
   description and either fold it into the closest category or create a new
@@ -481,6 +530,8 @@ Field notes:
   submitted to the improvement leaderboard. Reverts can omit it.
 - `iterations[].deltaMs` / `deltaPct` — measured north-star change for that
   single iteration (median vs. the previous kept state), negative = faster.
+  Required on every measured iteration, kept or reverted. An iteration with
+  neither these nor `measured` is a stub, not a result, and is ignored.
 - `genericKeepPct` / `siteSpecificKeepPct` — the split above, over kept
   iterations only, as whole percents that add to 100. Submitted with the site
   stats. Leave both out when the run kept nothing.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Jacob's live run showed real `[RESULT]` lines in AGENT THINKING — including a keep that took warm LCP from 4658 ms to 3608 ms — while RUN TIMINGS still had one bar, `TOTAL RUNS: 1`, `LOOP 000`, `RESULT: PENDING`, and a CANDIDATE column sitting on the baseline at 0% on every metric. The panel also printed its own tell: `[RESULT] Unnamed experiment: no delta recorded — reverted`.

The hypothesis in the report is confirmed, and it is two bugs on two sides of the same contract.

## What was wrong

**The dashboard would only plot a delta.** `deriveRuns()` skipped any iteration without a finite `deltaMs`, so an agent that recorded where a run *landed* rather than how far it *moved* got no bar at all — the measurement was in the file, in a shape the reader did not accept. The same test drove `deriveVerdict()`, so the middle panel stayed on `LOOP 000 / measuring baseline / PENDING` too.

**The candidate column read only `results.final`.** The skill has the agent write `final` in the last full measurement pass before it exits, so for the entire run `candidate` fell back to `baseline` and every metric read 0%. That is not "the experiments are not working", it is "the final pass has not happened yet", and the panel could not tell the difference.

**A row with no numbers was announced as a measured miss.** `ingest()` emitted one `RESULT` line per new array entry regardless of content, so a `{"kept": true}` stub became `Unnamed experiment: no delta recorded — reverted` — a miss reported for an experiment that had not been measured, and in that case for one that was about to be kept.

**Nothing ever told the agent to put the numbers in the file.** The skill said "update `results.json` after every iteration" and separately described a `[RESULT]` log line, and an agent could satisfy both by writing the deltas into the log and a bare row into the file. The log is prose; nothing reads it for a value.

## What changed

`packages/cli/lib/dashboard.js` grows one shared walk, `measuredIterations()`, that both the chart and the verdict use. An iteration is measured when it carries an absolute north-star value **or** a finite delta — either way round, kept or reverted, since a miss was profiled just as carefully as a keep. Absolutes win over deltas, because they are what was measured rather than a running total. What is still not a run: a skip (`skipped: true`, or `kept: "skipped"`), and a row carrying no measurement at all.

`deriveRuns()` now also returns the `candidate` run — the last kept one, or the baseline when nothing has been kept — and `deriveMetrics()` uses its metric snapshot when `results.final` is absent. So a keep moves the CANDIDATE column and the `exp_NNN` label the moment it is recorded, and `final` still wins once it is written.

`loopView.ingest()` announces a row when it carries a measurement, keyed by position rather than by a seen-count, so an agent that writes the row first and the numbers on the next write still gets exactly one `RESULT` line when they land.

`packages/skill/SKILL.md` closes the write path: rewrite `results.json` the moment a `[TEST]` finishes with the row that test produced — a generic `name`, `deltaMs`/`deltaPct`, `kept`, and a new `measured` field holding the absolute medians it landed on, in the same shape as `baseline` — and refresh `results.final` on a keep instead of waiting for the exit. It says plainly that a stub is not a result, that a miss is a row too, and that a `[SKIP]` is neither.

## Before / after

The same session replayed through the real `createLoopView` + `buildDashboard`: a baseline, a miss that recorded only the absolute it landed on, and an unfilled `{kept: true}` stub.

Before, on `main` — the bogus line, one bar, `LOOP 000`, candidate glued to baseline:

```
│ [RESULT]  Preload LCP image: no delta recorded — reverted, did not beat the noise floor │
│ [RESULT]  Unnamed experiment: no delta recorded — kept                                  │
│ LOOP 000   CURRENT EXPERIMENT: measuring baseline                                       │
│ STATUS: RUNNING  | RESULT: PENDING                                                      │
│ LCP    4.66 s   4.66 s   0%        CANDIDATE exp_000   BASELINE exp_000                 │
│ ROLLING AVERAGE (last 5 runs): 4659 ms  |  TOTAL RUNS: 1                                │
```

After — the miss is a bar, the stub says nothing, the loop advances:

```
│ [RESULT]  Preload LCP image: +210ms / +4.5% on lcp — reverted, did not beat the noise floor │
│ LOOP 001   CURRENT EXPERIMENT: Preload LCP image                                            │
│ STATUS: RUNNING  | RESULT: REGRESSED                                                        │
│ ROLLING AVERAGE (last 5 runs): 4764 ms  |  TOTAL RUNS: 2                                    │
```

And with the keep recorded as the skill now requires, before any `final` is written:

```
│ LOOP 002   CURRENT EXPERIMENT: Defer non-critical scripts                                   │
│ STATUS: RUNNING  | RESULT: IMPROVED                                                         │
│ PAGE LOAD TIME (LCP)    3.61 s   4.66 s  -22.6%     CANDIDATE exp_002   BASELINE exp_000    │
│       4659   4869   ★3608                                                                   │
│ ROLLING AVERAGE (last 5 runs): 4379 ms  |  IMPROVEMENT vs BASELINE: -22.6%  |  TOTAL RUNS: 3│
```

## Tests

New coverage in `dashboard.test.mjs` and `loopview.test.mjs` for a keep adding a bar and moving the candidate, a revert still adding a bar without moving it, an iteration plotted from an absolute alone, an absolute beating a stale delta, a stub being neither a run nor a verdict nor a `RESULT` line, and a skip never getting a bar. `npm test` is green at 148 tests.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c4f826d-98b5-48fc-b7bc-e6c3d7f49516?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c4f826d-98b5-48fc-b7bc-e6c3d7f49516&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

