### PR TITLE
Curated chain-of-thought traces: a second, separate question and a private store

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ What happens:
    makefaster shows [its own dashboard](#the-dashboard) instead.
 7. **Stops when the whole checklist has been walked and the extras are done** —
    not at five runs, and not because several attempts in a row missed — then
-   leaves the dashboard and shows the end screen with three
+   leaves the dashboard and shows the end screen with its
    questions:
    - **Loop more?** — another round: whatever is left of the checklist first,
      then more extras.
@@ -78,6 +78,11 @@ What happens:
    - **Submit anonymous improvements data?** — no URL; category names,
      descriptions, and deltas only. Novel improvements become new categories
      on the improvement leaderboard.
+   - **Submit this session's chain of thought?** — a separate decision, asked
+     once the two above have been answered and defaulting to no. The agent's own
+     reasoning text, kept privately to post-train a small model on how the loop
+     reasons; never published anywhere. See
+     [Chains of thought](#chains-of-thought).
 
 ```text
 Usage: npx makefaster [dir] [options]
@@ -393,7 +398,11 @@ start empty and grow as loops report results:
 | `GET /api/health` | `{ ok, embedder, threshold }` | — |
 | `POST /api/submit-site` | `{ url, favicon?, name?, prUrl?, genericKeepPct?, siteSpecificKeepPct?, tips?, lcpBefore?, lcpRaw, lcpDelta, ttiBefore?, ttiRaw, ttiDelta, mode: cold\|warm }` — upserts the site's row; URL + favicon shown publicly, `name` reduced to the product's own name, `prUrl` (or `pr`) linked from it. `tips` is up to 10 `{ text, about? }` notes to the catalog maintainers (280/80 chars, clamped): stored privately, acknowledged only as a count, never served by any endpoint | `MakefasterAPI.submitSite(payload)` |
 | `POST /api/submit-improvements` | `{ improvements: [{ name, description?, deltaMs?, deltaPct? }] }` — anonymous; names and descriptions are normalized to generic techniques and embedding-matched into categories | `MakefasterAPI.submitImprovements(payload)` |
+| `POST /api/submit-trace` | `{ thinking: [{ text }], results?, runId?, product?, prUrl?, agent?, model?, round?, startedAt?, submittedAt?, resultsSubmitted? }` — one run's chain of thought. Stored privately (see [Chains of thought](#chains-of-thought)); there is no GET counterpart and nothing it holds appears on a board or in `/data/*.json` | — |
 | `POST /api/openrouter/v1/chat/completions` | OpenAI-compatible chat completions for the CLI's hosted provider, proxied to OpenRouter under the server's own credential | — |
+
+Unknown paths under `/api/` answer `404` rather than the SPA shell, so a route
+nobody wrote cannot become one the static fallback answers.
 
 Each metric has both ends of the run: `lcpRaw`/`ttiRaw` are the measurement
 after the last kept change, `lcpBefore`/`ttiBefore` the pre-loop baseline, and
@@ -459,6 +468,119 @@ deliberately narrow ([`backend/internal/inference`](backend/internal/inference))
 
 Set the key at deploy time; there is none in this repo, and the tests use an
 `httptest` upstream and a placeholder string.
+
+### Chains of thought
+
+`POST /api/submit-trace` collects the one thing the loop produces that neither
+board can hold: **how the agent reasoned**. A curated set of those traces is
+what a small model can be post-trained on — the checklist walk, the hypothesis
+that did not survive the measurement, the skip and the reason for it.
+
+It is a **separate question in the CLI**, asked after the results question has
+been answered and defaulting to no:
+
+```text
+  2. Submit stats to the Site leaderboard?          [y/N]
+  3. Submit anonymous improvements data?            [y/N]
+
+  4. Submit this session's chain of thought?        [y/N]   ← its own decision
+```
+
+The two are not bundled. Uploading results and declining the trace is a normal
+answer, declining the results and sending the trace is a normal answer, and
+both and neither are too — the trace records which happened
+(`resultsSubmitted`), because a training set should know whether the run it is
+reading also went on a board. Nothing is ever auto-uploaded: the prompt defaults
+to no and takes an explicit yes.
+
+**What the CLI sends.** The reasoning text and nothing else. The four providers
+all stream reasoning, and makefaster otherwise collapses every bit of it into
+the word `thinking` on the way to the progress line, so
+[`packages/cli/lib/thinkingTrace.js`](packages/cli/lib/thinkingTrace.js) reads
+the field each one documents as reasoning — an ACP `agent_thought_chunk`, a
+Claude `thinking` block, a Codex `reasoning` item, an OpenRouter `reasoning`
+field — and appends it to `.makefaster/thinking-trace.jsonl`. Streamed chunks
+coalesce into blocks; the first event that is not a thought closes one. Nothing
+reads the file during the run, it is ignored by git along with the rest of
+`.makefaster/`, and it can be read before answering — the prompt names it.
+
+`.makefaster/thinking.log` is **not** this file and has not changed: it is the
+agent's own one-line-per-step report, it is the only thing the dashboard shows,
+and it stays user-facing.
+
+The payload also carries the distilled `results.json` — the iteration list with
+its keep/revert verdicts, plus both ends of the run — and the metadata that
+lines a trace up with the run that produced it: product name, `prUrl`, agent and
+model, round, timestamps. It carries no diff: the loop's changes are in the pull
+request the site row already links to, and shipping a user's source under a
+question about reasoning would be answering a question they were not asked.
+
+**Where it goes.** One JSON document per run under `MAKEFASTER_TRACE_DIR`
+(`/var/lib/makefaster/traces` by default), as
+`<yyyy-mm>/<run id>.json`, in a `0700` directory as a `0600` file — outside the
+repo and outside `FRONTEND_DIR`, because the one thing that must never happen to
+a trace is being served as a static asset. The `traces` table is the index
+beside it (counts and metadata, not content) so a year of collection is still
+queryable. A run that submits twice replaces its own document rather than adding
+a second copy.
+
+Nothing serves any of it. There is no `GET`, no board, no `/data/*.json` field,
+and it is not where the CLI's imported checklist comes from — that is
+`GET /data/improvements.json` and only that. Setting `MAKEFASTER_TRACE_DIR=off`
+collects nothing, and a deployment with no directory answers `503` naming the
+setting.
+
+**What cannot get in.** Everything stored is whitelisted rather than filtered:
+`thinking` is read for text, and `results` is re-read field by field, so an
+iteration's `notes` — where the skill puts everything specific to one repo —
+stays on the submitter's disk. A payload that carries a tool transcript, a build
+log or a `tool_result` block (`messages`, `toolResults`, `stdout`, a block whose
+`type` names a tool…) is **refused with the reason** rather than quietly
+stripped: a trace that silently is not what it claims would be worse than no
+trace. And the caps mean a `yarn build` log cannot arrive as reasoning either —
+400 blocks, 8k characters each, 200k in total, 200 iterations, a 96 KB diff,
+behind a 512 KB body wall. Whatever had to be clamped comes back in the
+response.
+
+#### Backfilling already-packed runs
+
+Speed Lab has runs on disk already, and those do not need to go through the TUI
+to get onto the box. `makefaster-traces` imports them directly:
+
+```bash
+cd backend && go build -o /usr/local/bin/makefaster-traces ./cmd/traces
+
+makefaster-traces import --dir /srv/backfill/2026-08     # a directory of runs
+makefaster-traces import --tar /srv/backfill/runs.tar.gz # or a tar/tar.gz
+makefaster-traces import --dir ./runs --dry-run          # validate, write nothing
+makefaster-traces list --limit 20                        # the private index
+```
+
+One directory per run, in the layout an export already writes:
+
+```text
+<run>/
+  meta.json        required — { runId?, product?, prUrl?, agent?, model?,
+                               round?, startedAt?, submittedAt?,
+                               resultsSubmitted? }
+  thinking.jsonl   required — one {"text": "…"} per line, in order
+                              (a bare JSON string per line also reads)
+  results.json     optional — the run's results.json
+  diff.patch       optional — the unified patch, truncated to the size cap
+```
+
+A `--tar` is a tar of the same tree; the first path segment of each entry is the
+run, so both `tar -cf runs.tar run-*/` and a tar with a wrapping directory
+import the same way. A run with no `runId` in its `meta.json` is named after its
+directory, so re-importing the same export is one trace rather than two, and a
+run already stored is skipped unless `--replace` — an interrupted backfill is
+safe to run again.
+
+Imports go through the same `internal/trace` value the endpoint produces, so an
+imported trace and a submitted one are indistinguishable once stored: same
+whitelisting, same caps, same refusal to accept tool output in place of
+thinking. `list` reads the index on the box; it is deliberately not an HTTP
+endpoint and deliberately not something the CLI can reach.
 
 ### Embeddings
 
@@ -552,7 +674,10 @@ cd backend && go build -o /usr/local/bin/makefaster-server ./cmd/server
 
 Migrations run on start, so a deploy is build, replace, restart. The process
 needs `MARIADB_DSN`, `FRONTEND_DIR`, and `MIGRATIONS_DIR` pointing at the
-shipped copies of `frontend/` and `backend/internal/db/migrations/`. Put a
+shipped copies of `frontend/` and `backend/internal/db/migrations/`. If it is to
+collect [chains of thought](#chains-of-thought) it also needs write access to
+`MAKEFASTER_TRACE_DIR` — somewhere private, outside `FRONTEND_DIR`, and it is
+not backed up by anything that publishes. Put a
 TLS-terminating proxy (Caddy/nginx/Cloudflare) in front and point the domain at
 it — the `npx makefaster` CLI submits to `https://makefaster.dev` by default,
 and elsewhere with `--api` or `MAKEFASTER_API_BASE`.
@@ -569,14 +694,24 @@ server too so the boards stay live.
 
 ```bash
 npm test                                    # CLI: detection, args, payloads,
-                                            # protocol children, catalog, dashboard
-cd backend && go test ./...                 # server, embedder, categorization
+                                            # protocol children, catalog, dashboard,
+                                            # the end screen's questions
+cd backend && go test ./...                 # server, embedder, categorization, traces
 ```
 
 The CLI suite spawns real protocol children — a stub agent speaking ACP and one
 speaking the codex app-server dialect — and asserts on the frames they receive,
 so the argv, the handshake, and the permission answers are proven rather than
 described. It needs no network, no database, and no signed-in agent CLI.
+
+The end screen's questions are a test rather than a promise: that the chain of
+thought is asked **after** the results question and not bundled with it, that
+its prompt defaults to no, that declining it posts nothing at all, that
+declining the results and accepting it still submits, and that the payload is
+thinking text plus the iteration list with no `notes` and nothing resembling a
+tool transcript. The trace capture is tested per provider stream — a reasoning
+chunk is captured, a tool call and plain assistant prose are not — along with
+the coalescing and the caps.
 
 
 The MariaDB-backed server tests skip unless a throwaway schema is named, so
@@ -597,6 +732,18 @@ static/SPA fallback and legacy redirects; CORS; and the body cap. They also run
 the two board migrations against the live rows they were written for: the
 generic-name rename (00002) and the generic-description backfill (00004), the
 latter both forwards and rolled back.
+
+The trace tests are the other half of the privacy claim. Both public documents
+are captured byte for byte before a trace is submitted and compared after, so a
+trace cannot change what the boards serve even in a field nobody thought to look
+at; the reasoning is then searched for by hand in both. The rest covers what has
+no route (`GET /api/submit-trace`, `/api/traces`, the document path — all `404`,
+none of them the SPA shell), the refusals (five shapes of tool transcript, each
+answered `400` with nothing written), the caps and the `413`, that a
+resubmission replaces rather than duplicates, that documents land `0600` in a
+`0700` directory, that a client-supplied run id cannot escape it
+(`../../etc/passwd`), and that the backfill importer reads both a directory and
+a tar — refusing tool output there too.
 
 The categorization and embedding tests need a realistic board to match against,
 so they read `backend/testdata/categories.json` — a frozen 50-row fixture that

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"database/sql"
 	"log/slog"
 	"net/http"
 	"os"
@@ -18,6 +19,7 @@ import (
 	httpapi "makefaster/internal/http"
 	"makefaster/internal/inference"
 	"makefaster/internal/store"
+	"makefaster/internal/trace"
 )
 
 func main() {
@@ -66,6 +68,11 @@ func main() {
 			"models", models.Models())
 	}
 
+	// The private trace store. A directory that cannot be prepared is not a
+	// reason to refuse to boot — the leaderboards are the product — so the
+	// endpoint answers 503 and the reason is logged once, here.
+	traces := openTraceVault(cfg, pool, logger)
+
 	server := httpapi.NewServer(httpapi.Options{
 		Store:       leaderboards,
 		Embedder:    embedder,
@@ -73,6 +80,7 @@ func main() {
 		FrontendDir: cfg.FrontendDir,
 		Logger:      logger,
 		Inference:   models,
+		Traces:      traces,
 	})
 
 	logger.Info("makefaster server listening",
@@ -93,4 +101,24 @@ func main() {
 		logger.Error("server stopped", "error", err)
 		os.Exit(1)
 	}
+}
+
+// openTraceVault prepares the private chain-of-thought store, or returns nil
+// when this deployment does not collect traces or cannot write where it was
+// told to. Nil is what makes POST /api/submit-trace answer 503 with the fix.
+func openTraceVault(cfg config.Config, pool *sql.DB, logger *slog.Logger) *trace.Vault {
+	if !cfg.TracesEnabled() {
+		logger.Info("chain-of-thought traces are off; POST /api/submit-trace will answer 503",
+			"traceDir", cfg.TraceDir)
+		return nil
+	}
+	vault, err := trace.NewVault(cfg.TraceDir, pool, logger)
+	if err != nil {
+		logger.Warn("could not prepare the trace directory; POST /api/submit-trace will answer 503",
+			"traceDir", cfg.TraceDir, "error", err)
+		return nil
+	}
+	logger.Info("chain-of-thought traces are stored privately and served by nothing",
+		"traceDir", vault.Dir())
+	return vault
 }

--- a/backend/cmd/traces/main.go
+++ b/backend/cmd/traces/main.go
@@ -1,0 +1,229 @@
+// Command traces manages the private chain-of-thought store from the box it
+// lives on. It exists so a backfill of already-packed runs can be imported
+// without going through the TUI, and so the stored set can be listed without an
+// HTTP endpoint — there is deliberately no route that reads a trace back.
+//
+//	makefaster-traces import --dir /srv/backfill/2026-08
+//	makefaster-traces import --tar /srv/backfill/runs.tar.gz
+//	makefaster-traces list --limit 20
+//
+// A packed run is one directory holding:
+//
+//	meta.json      required — { runId?, product?, prUrl?, agent?, model?,
+//	                            round?, startedAt?, submittedAt?,
+//	                            resultsSubmitted? }
+//	thinking.jsonl required — one {"text": "…"} per line, in order
+//	results.json   optional — the run's results.json
+//	diff.patch     optional — the unified patch, truncated to the size cap
+//
+// A --dir is a directory of those directories (or one of them). A --tar is a
+// tar, gzipped when the name says so, of the same tree. Imports go through the
+// same validation and the same caps as POST /api/submit-trace, so an imported
+// trace and a submitted one are indistinguishable once stored — including the
+// refusal to accept a tool transcript in place of thinking.
+//
+// Re-running an import is safe: a run already in the store is skipped unless
+// --replace is given, so an interrupted backfill can simply be run again.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/joho/godotenv"
+
+	"makefaster/internal/config"
+	"makefaster/internal/db"
+	"makefaster/internal/trace"
+)
+
+const usage = `makefaster-traces — the private chain-of-thought store, from the box it lives on
+
+  makefaster-traces import --dir <path>   import every packed run under <path>
+  makefaster-traces import --tar <file>   import packed runs from a tar/tar.gz
+  makefaster-traces list [--limit N]      list what is stored, newest first
+
+Flags:
+  --dir <path>     a directory of packed runs, or one packed run
+  --tar <file>     a tar or tar.gz of the same layout ("-" reads stdin)
+  --replace        overwrite runs already in the store (default: skip them)
+  --dry-run        validate and report without writing anything
+  --limit N        how many rows to list (default 50)
+
+A packed run is a directory holding meta.json and thinking.jsonl, optionally
+results.json and diff.patch. Configuration comes from the environment, the same
+way the server reads it: MAKEFASTER_TRACE_DIR and MARIADB_DSN.
+`
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprint(os.Stderr, usage)
+		os.Exit(2)
+	}
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	_ = godotenv.Load(".env")
+	_ = godotenv.Load("../.env")
+
+	var err error
+	switch os.Args[1] {
+	case "import":
+		err = runImport(os.Args[2:], logger)
+	case "list":
+		err = runList(os.Args[2:], logger)
+	case "-h", "--help", "help":
+		fmt.Print(usage)
+		return
+	default:
+		fmt.Fprintf(os.Stderr, "unknown command %q\n\n%s", os.Args[1], usage)
+		os.Exit(2)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func runImport(args []string, logger *slog.Logger) error {
+	flags := flag.NewFlagSet("import", flag.ContinueOnError)
+	dir := flags.String("dir", "", "a directory of packed runs, or one packed run")
+	tarPath := flags.String("tar", "", `a tar or tar.gz of packed runs ("-" reads stdin)`)
+	replace := flags.Bool("replace", false, "overwrite runs already in the store")
+	dryRun := flags.Bool("dry-run", false, "validate and report without writing")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+	if (*dir == "") == (*tarPath == "") {
+		return fmt.Errorf("pass exactly one of --dir or --tar")
+	}
+
+	traces, err := load(*dir, *tarPath)
+	if err != nil {
+		return err
+	}
+	if len(traces) == 0 {
+		return fmt.Errorf("no packed runs found (expected directories holding %s and %s)", "meta.json", "thinking.jsonl")
+	}
+
+	if *dryRun {
+		for _, candidate := range traces {
+			fmt.Printf("would import %s — %d blocks, %d chars, %d iterations%s\n",
+				candidate.RunID, len(candidate.Thinking), candidate.ThinkingChars(),
+				candidate.IterationCount(), truncatedSuffix(candidate.Truncated))
+		}
+		fmt.Printf("%d run(s) validated, nothing written (--dry-run)\n", len(traces))
+		return nil
+	}
+
+	vault, closeVault, err := openVault(logger)
+	if err != nil {
+		return err
+	}
+	defer closeVault()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	imported, skipped := 0, 0
+	for _, candidate := range traces {
+		record, err := vault.Save(ctx, candidate, *replace)
+		if err != nil {
+			return fmt.Errorf("import %s: %w", candidate.RunID, err)
+		}
+		if !record.Created && !*replace {
+			skipped++
+			fmt.Printf("skipped %s — already stored (pass --replace to overwrite)\n", record.RunID)
+			continue
+		}
+		imported++
+		fmt.Printf("imported %s — %d blocks, %d chars, %d iterations%s\n",
+			record.RunID, record.ThinkingBlocks, record.ThinkingChars, record.Iterations,
+			truncatedSuffix(record.Truncated))
+	}
+	fmt.Printf("%d imported, %d skipped, into %s\n", imported, skipped, vault.Dir())
+	return nil
+}
+
+func runList(args []string, logger *slog.Logger) error {
+	flags := flag.NewFlagSet("list", flag.ContinueOnError)
+	limit := flags.Int("limit", 50, "how many rows to list")
+	if err := flags.Parse(args); err != nil {
+		return err
+	}
+
+	vault, closeVault, err := openVault(logger)
+	if err != nil {
+		return err
+	}
+	defer closeVault()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	rows, err := vault.List(ctx, *limit)
+	if err != nil {
+		return err
+	}
+	if len(rows) == 0 {
+		fmt.Printf("no traces stored under %s\n", vault.Dir())
+		return nil
+	}
+	fmt.Printf("%-19s  %-7s  %-6s  %-6s  %-7s  %s\n", "STORED", "SOURCE", "BLOCKS", "CHARS", "ITERS", "RUN / PRODUCT")
+	for _, row := range rows {
+		fmt.Printf("%-19s  %-7s  %-6d  %-6d  %-7d  %s  %s\n",
+			row.CreatedAt.UTC().Format("2006-01-02 15:04:05"), row.Source,
+			row.ThinkingBlocks, row.ThinkingChars, row.Iterations, row.RunID, row.Product)
+	}
+	fmt.Printf("\n%d row(s). Documents are under %s and are served by no endpoint.\n", len(rows), vault.Dir())
+	return nil
+}
+
+func load(dir, tarPath string) ([]trace.Trace, error) {
+	if dir != "" {
+		return trace.LoadDir(dir)
+	}
+	if tarPath == "-" {
+		return trace.LoadTar(os.Stdin, false)
+	}
+	file, err := os.Open(tarPath)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", tarPath, err)
+	}
+	defer file.Close()
+	gzipped := strings.HasSuffix(tarPath, ".gz") || strings.HasSuffix(tarPath, ".tgz")
+	return trace.LoadTar(file, gzipped)
+}
+
+// openVault reads the same configuration the server does, so the tool cannot
+// end up writing somewhere the server does not read.
+func openVault(logger *slog.Logger) (*trace.Vault, func(), error) {
+	cfg := config.Load()
+	if !cfg.TracesEnabled() {
+		return nil, nil, fmt.Errorf("MAKEFASTER_TRACE_DIR is off or unset, so there is nowhere to store traces")
+	}
+	pool, err := db.Open(cfg.MariaDSN)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open mariadb: %w", err)
+	}
+	if err := db.Migrate(pool, cfg.MigrationsDir); err != nil {
+		pool.Close()
+		return nil, nil, fmt.Errorf("migrate: %w", err)
+	}
+	vault, err := trace.NewVault(cfg.TraceDir, pool, logger)
+	if err != nil {
+		pool.Close()
+		return nil, nil, err
+	}
+	return vault, func() { pool.Close() }, nil
+}
+
+func truncatedSuffix(notes []string) string {
+	if len(notes) == 0 {
+		return ""
+	}
+	return " (" + strings.Join(notes, "; ") + ")"
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -17,6 +17,12 @@ const (
 	DefaultFrontendDir   = "../frontend"
 	DefaultSeedDir       = "../data"
 
+	// Where the private chain-of-thought traces are stored. Outside the repo
+	// and outside FRONTEND_DIR on purpose: the one thing that must never
+	// happen to a trace is being served as a static file. Setting
+	// MAKEFASTER_TRACE_DIR to "off" turns collection off entirely.
+	DefaultTraceDir = "/var/lib/makefaster/traces"
+
 	DefaultEmbeddingsModel   = "text-embedding-3-small"
 	DefaultEmbeddingsBaseURL = "https://api.openai.com/v1"
 
@@ -57,8 +63,16 @@ type Config struct {
 	MigrationsDir string
 	FrontendDir   string
 	SeedDir       string
+	TraceDir      string
 	Embeddings    Embeddings
 	Inference     Inference
+}
+
+// TracesEnabled reports whether this deployment collects chains of thought. An
+// explicit "off" (or an empty value) means it does not, and
+// POST /api/submit-trace answers 503 saying so.
+func (c Config) TracesEnabled() bool {
+	return c.TraceDir != "" && !strings.EqualFold(c.TraceDir, "off")
 }
 
 // Addr is the host:port passed to net/http.
@@ -75,6 +89,7 @@ func Load() Config {
 		MigrationsDir: envString("MIGRATIONS_DIR", DefaultMigrationsDir),
 		FrontendDir:   envString("FRONTEND_DIR", DefaultFrontendDir),
 		SeedDir:       envString("SEED_DIR", DefaultSeedDir),
+		TraceDir:      envString("MAKEFASTER_TRACE_DIR", DefaultTraceDir),
 		Embeddings:    loadEmbeddings(),
 		Inference:     loadInference(),
 	}

--- a/backend/internal/db/migrations/00011_traces.sql
+++ b/backend/internal/db/migrations/00011_traces.sql
@@ -1,0 +1,46 @@
+-- +goose Up
+-- Traces: the index of the curated reasoning traces a run may submit after its
+-- results, for post-training a small model on how the makefaster loop reasons.
+--
+-- This table is the catalog, not the content: the thinking blocks themselves
+-- live as one JSON document per run under the server's private trace directory
+-- (MAKEFASTER_TRACE_DIR, e.g. /var/lib/makefaster/traces), which no HTTP route
+-- serves. `path` is that document, relative to the directory root.
+--
+-- Nothing here is public. No endpoint reads this table, no board renders it,
+-- and it is not the source of the checklist the CLI imports — the same posture
+-- as `tips` (migration 00010), for the same reason: a trace is only ever
+-- submitted on an explicit, separate yes, and publishing it would be an upload
+-- the user never made.
+CREATE TABLE traces (
+  id                BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+  -- The run the trace came from. Unique, so a resubmitted run replaces its
+  -- trace instead of adding a second copy to the training set.
+  run_id            VARCHAR(64)     NOT NULL,
+  -- 'cli' for a submission through POST /api/submit-trace, 'import' for a
+  -- backfill of already-packed runs (cmd/traces import).
+  source            VARCHAR(16)     NOT NULL DEFAULT 'cli',
+  product           VARCHAR(200)    NOT NULL DEFAULT '',
+  pr_url            VARCHAR(500)    NOT NULL DEFAULT '',
+  agent             VARCHAR(40)     NOT NULL DEFAULT '',
+  model             VARCHAR(120)    NOT NULL DEFAULT '',
+  round             INT             NOT NULL DEFAULT 0,
+  thinking_blocks   INT             NOT NULL DEFAULT 0,
+  thinking_chars    INT             NOT NULL DEFAULT 0,
+  iterations        INT             NOT NULL DEFAULT 0,
+  has_results       TINYINT(1)      NOT NULL DEFAULT 0,
+  has_diff          TINYINT(1)      NOT NULL DEFAULT 0,
+  -- Whether the same run also submitted its results to the public boards, so a
+  -- trace can be lined up with the site row it belongs to.
+  results_submitted TINYINT(1)      NOT NULL DEFAULT 0,
+  path              VARCHAR(255)    NOT NULL,
+  started_at        DATETIME(3)     NULL,
+  submitted_at      DATETIME(3)     NULL,
+  created_at        DATETIME(3)     NOT NULL,
+  PRIMARY KEY (id),
+  UNIQUE KEY traces_run_id (run_id),
+  KEY traces_created_at (created_at)
+) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_unicode_ci;
+
+-- +goose Down
+DROP TABLE traces;

--- a/backend/internal/http/migrations_test.go
+++ b/backend/internal/http/migrations_test.go
@@ -62,7 +62,7 @@ func databaseAtVersion(t *testing.T, version int64) *sql.DB {
 	}
 	t.Cleanup(func() { pool.Close() })
 
-	for _, table := range []string{"sites", "improvement_categories", "tips", "goose_db_version"} {
+	for _, table := range []string{"sites", "improvement_categories", "tips", "traces", "goose_db_version"} {
 		if _, err := pool.Exec("DROP TABLE IF EXISTS " + table); err != nil {
 			t.Fatalf("drop %s: %v", table, err)
 		}

--- a/backend/internal/http/server.go
+++ b/backend/internal/http/server.go
@@ -12,9 +12,15 @@
 //	                                optional private tips for the catalog
 //	                                maintainers (stored, never served)
 //	POST /api/submit-improvements    anonymous improvements, embedding-matched
+//	POST /api/submit-trace          one run's chain of thought, stored privately
+//	                                and served by nothing (see internal/trace)
 //	POST /api/openrouter/v1/chat/completions
 //	                                the subsidized model proxy the CLI's
 //	                                `makefaster` provider runs on
+//
+// There is no GET counterpart to submit-trace, and adding one would be a
+// mistake rather than a feature: unknown GET paths under /api/ answer 404 so
+// that a route nobody wrote cannot become a route the SPA shell answers.
 package httpapi
 
 import (
@@ -23,6 +29,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -30,6 +37,7 @@ import (
 	"makefaster/internal/inference"
 	"makefaster/internal/leaderboard"
 	"makefaster/internal/store"
+	"makefaster/internal/trace"
 )
 
 const (
@@ -46,6 +54,13 @@ const (
 	// The proxy's own body ceiling. A conversation with a few files in it is
 	// large, but not this large, and the request is read into memory.
 	inferenceBodyLimitBytes = 1024 * 1024
+
+	// A trace is a session's reasoning plus its iteration list, which is more
+	// than a leaderboard row and much less than a conversation. The per-block,
+	// per-trace and total caps in internal/trace do the real work; this is the
+	// outer wall, so a client that ignores them is refused before the body is
+	// read rather than after.
+	traceBodyLimitBytes = 512 * 1024
 )
 
 type Server struct {
@@ -55,6 +70,10 @@ type Server struct {
 	frontendDir string
 	logger      *slog.Logger
 	inference   *inference.Proxy
+
+	// traces is the private trace store. Nil is a supported state: the
+	// deployment collects no traces and POST /api/submit-trace answers 503.
+	traces *trace.Vault
 
 	limiter          *rateLimiter
 	inferenceLimiter *rateLimiter
@@ -75,6 +94,10 @@ type Options struct {
 	// Inference is optional: a nil proxy answers the inference route with the
 	// same 503 an unconfigured credential does.
 	Inference *inference.Proxy
+
+	// Traces is optional in the same way: a nil vault means this deployment
+	// stores no chains of thought, and says so.
+	Traces *trace.Vault
 }
 
 func NewServer(opts Options) *Server {
@@ -93,6 +116,7 @@ func NewServer(opts Options) *Server {
 		frontendDir:      opts.FrontendDir,
 		logger:           logger,
 		inference:        proxy,
+		traces:           opts.Traces,
 		limiter:          newRateLimiter(rateLimitMaxPosts),
 		inferenceLimiter: newRateLimiter(inferenceRateLimitMax),
 	}
@@ -120,6 +144,8 @@ func (s *Server) route(w http.ResponseWriter, r *http.Request) {
 			s.handleSubmitSite(w, r)
 		case "/api/submit-improvements":
 			s.handleSubmitImprovements(w, r)
+		case "/api/submit-trace":
+			s.handleSubmitTrace(w, r)
 		case "/api/openrouter/v1/chat/completions":
 			s.handleInferenceChat(w, r)
 		default:
@@ -146,6 +172,15 @@ func (s *Server) route(w http.ResponseWriter, r *http.Request) {
 				},
 			})
 		default:
+			// Everything under /api/ that is not a route above is a 404, not
+			// the SPA shell. The write endpoints store things that are never
+			// meant to be read back — private catalog tips, chains of thought —
+			// so "no GET exists for that" has to be the answer here, not an
+			// accident of the static fallback.
+			if strings.HasPrefix(r.URL.Path, "/api/") {
+				s.writeJSON(w, http.StatusNotFound, errorBody("unknown endpoint"))
+				return
+			}
 			s.serveStatic(w, r)
 		}
 
@@ -309,12 +344,91 @@ func (s *Server) foldImprovements(r *http.Request, improvements []leaderboard.Im
 	return results, nil
 }
 
+// submitTraceResponse acknowledges a stored chain of thought. It reports what
+// was kept and what had to be clamped, and nothing about where it went: the
+// server's filesystem layout is not the client's business, and there is no
+// endpoint that would read the document back anyway.
+type submitTraceResponse struct {
+	OK             bool     `json:"ok"`
+	RunID          string   `json:"runId"`
+	ThinkingBlocks int      `json:"thinkingBlocks"`
+	ThinkingChars  int      `json:"thinkingChars"`
+	Iterations     int      `json:"iterations,omitempty"`
+	Truncated      []string `json:"truncated,omitempty"`
+}
+
+// handleSubmitTrace stores one run's chain of thought.
+//
+// This endpoint is write-only in the strongest sense the server has: the
+// document lands under a private directory (0700/0600) plus an index row, and
+// nothing serves either. It is not on a board, not in GET /data/*.json, and not
+// in the checklist the CLI imports — that list comes from the improvement
+// categories and only from them.
+//
+// It is also never the consequence of another answer. The CLI asks for a trace
+// as its own question, after the results question has been answered, and
+// defaults it to no; this handler's job is to hold up that promise on the
+// server side by storing what arrives and publishing none of it.
+func (s *Server) handleSubmitTrace(w http.ResponseWriter, r *http.Request) {
+	if s.traces == nil {
+		s.writeJSON(w, http.StatusServiceUnavailable, errorBody(
+			"this deployment does not collect chains of thought (MAKEFASTER_TRACE_DIR is unset)"))
+		return
+	}
+	body, ok := s.readBody(w, r)
+	if !ok {
+		return
+	}
+	submission, err := trace.DecodeSubmission(body, time.Now())
+	if err != nil {
+		var validation *trace.ValidationError
+		if errors.As(err, &validation) {
+			s.writeJSON(w, http.StatusBadRequest, errorPayload{OK: false, Errors: validation.Errors})
+			return
+		}
+		s.fail(w, err)
+		return
+	}
+
+	record, err := s.traces.Save(r.Context(), submission, true)
+	if err != nil {
+		s.fail(w, err)
+		return
+	}
+
+	status := http.StatusOK
+	if record.Created {
+		status = http.StatusCreated
+	}
+	// The log line counts; it never carries the reasoning itself.
+	s.logger.Info("submit-trace",
+		"runId", record.RunID,
+		"agent", submission.Agent,
+		"blocks", record.ThinkingBlocks,
+		"chars", record.ThinkingChars,
+		"iterations", record.Iterations,
+		"resultsSubmitted", submission.ResultsSubmitted,
+		"created", record.Created)
+	s.writeJSON(w, status, submitTraceResponse{
+		OK:             true,
+		RunID:          record.RunID,
+		ThinkingBlocks: record.ThinkingBlocks,
+		ThinkingChars:  record.ThinkingChars,
+		Iterations:     record.Iterations,
+		Truncated:      record.Truncated,
+	})
+}
+
 // readBody reads at most 256 KB of request body, answering 413 beyond that —
-// except on the inference route, whose payload is a whole conversation.
+// except on the inference route, whose payload is a whole conversation, and the
+// trace route, whose payload is a session's reasoning.
 func (s *Server) readBody(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
 	limit := bodyLimitBytes
-	if r.URL.Path == "/api/openrouter/v1/chat/completions" {
+	switch r.URL.Path {
+	case "/api/openrouter/v1/chat/completions":
 		limit = inferenceBodyLimitBytes
+	case "/api/submit-trace":
+		limit = traceBodyLimitBytes
 	}
 	body, err := io.ReadAll(io.LimitReader(r.Body, int64(limit)+1))
 	if err != nil {

--- a/backend/internal/http/server_test.go
+++ b/backend/internal/http/server_test.go
@@ -49,7 +49,7 @@ func freshDatabase(t *testing.T) *sql.DB {
 	}
 	t.Cleanup(func() { pool.Close() })
 
-	for _, table := range []string{"sites", "improvement_categories", "tips", "goose_db_version"} {
+	for _, table := range []string{"sites", "improvement_categories", "tips", "traces", "goose_db_version"} {
 		if _, err := pool.Exec("DROP TABLE IF EXISTS " + table); err != nil {
 			t.Fatalf("drop %s: %v", table, err)
 		}

--- a/backend/internal/http/traces_test.go
+++ b/backend/internal/http/traces_test.go
@@ -1,0 +1,379 @@
+package httpapi_test
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/fs"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"makefaster/internal/embedding"
+	httpapi "makefaster/internal/http"
+	"makefaster/internal/store"
+	"makefaster/internal/trace"
+)
+
+// bootWithTraces is `boot` plus a private trace vault rooted in a temporary
+// directory, and it returns that directory so a test can look at what actually
+// landed on disk.
+func bootWithTraces(t *testing.T, pool *sql.DB) (*httptest.Server, string) {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "traces")
+	vault, err := trace.NewVault(dir, pool, nil)
+	if err != nil {
+		t.Fatalf("new vault: %v", err)
+	}
+
+	leaderboards := store.New(pool)
+	if err := leaderboards.Seed(context.Background(), fixtureSeedDir()); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	embedder, threshold := embedding.New(embedding.Options{}, nil)
+	server := httpapi.NewServer(httpapi.Options{
+		Store:       leaderboards,
+		Embedder:    embedder,
+		Threshold:   threshold,
+		FrontendDir: frontendFixture(t),
+		Traces:      vault,
+	})
+	httpServer := httptest.NewServer(server.Handler())
+	t.Cleanup(httpServer.Close)
+	return httpServer, dir
+}
+
+func getRaw(t *testing.T, url string) (int, string) {
+	t.Helper()
+	res, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer res.Body.Close()
+	body, _ := io.ReadAll(res.Body)
+	return res.StatusCode, string(body)
+}
+
+// storedDocuments reads every trace document under the vault root, so a test can
+// assert on what was written rather than on what the response said.
+func storedDocuments(t *testing.T, dir string) []string {
+	t.Helper()
+	var documents []string
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil || entry.IsDir() || filepath.Ext(path) != ".json" {
+			return err
+		}
+		contents, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		info, statErr := entry.Info()
+		if statErr != nil {
+			return statErr
+		}
+		// A trace is private on disk, not only in the route table.
+		if perm := info.Mode().Perm(); perm != 0o600 {
+			t.Errorf("%s has mode %o, want 600", path, perm)
+		}
+		documents = append(documents, string(contents))
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk %s: %v", dir, err)
+	}
+	return documents
+}
+
+const traceBody = `{
+	"runId": "run-abc-123",
+	"product": "Speedy",
+	"prUrl": "https://github.com/jjcm/speedy/pull/7",
+	"agent": "cursor",
+	"model": "claude-fable-5",
+	"round": 1,
+	"startedAt": "2026-08-25T10:00:00.000Z",
+	"submittedAt": "2026-08-25T11:00:00.000Z",
+	"resultsSubmitted": true,
+	"thinking": [
+		{"text": "The hero image is the LCP element, so the font swap cannot be what is holding this back."},
+		{"text": "Preloading it moved the number 180ms, which is over the noise floor, so keep it."}
+	],
+	"results": {
+		"northStar": "lcp",
+		"baseline": {"cold": {"lcpMs": 2400, "ttiMs": 3100}},
+		"final": {"cold": {"lcpMs": 2100, "ttiMs": 2900}},
+		"iterations": [
+			{"name": "Preload the hero image", "kept": true, "deltaMs": -180, "deltaPct": -7.5, "phase": "checklist"},
+			{"name": "Defer the analytics SDK", "kept": false, "deltaMs": -4}
+		]
+	}
+}`
+
+// The load-bearing promise: a trace is stored and published nowhere. Both public
+// documents are captured byte for byte before the trace is submitted and
+// compared after, so a trace cannot change what the boards serve even in a
+// field nobody thought to look at.
+func TestSubmitTraceStoresPrivatelyAndLeavesThePublicJSONUnchanged(t *testing.T) {
+	pool := freshDatabase(t)
+	server, dir := bootWithTraces(t, pool)
+	base := server.URL
+
+	// A board with real rows on it, so "unchanged" means something.
+	if status := postJSON(t, base+"/api/submit-site",
+		`{"url":"https://speedy.example.com","mode":"cold","lcpRaw":2100,"lcpDelta":-12,"ttiRaw":2900,"ttiDelta":-6}`, nil); status != http.StatusCreated {
+		t.Fatalf("submit-site = %d, want 201", status)
+	}
+	if status := postJSON(t, base+"/api/submit-improvements",
+		`{"improvements":[{"name":"Preload the hero image","description":"Preload the LCP image","deltaMs":-180}]}`, nil); status != http.StatusOK {
+		t.Fatalf("submit-improvements = %d, want 200", status)
+	}
+
+	_, sitesBefore := getRaw(t, base+"/data/sites.json")
+	_, improvementsBefore := getRaw(t, base+"/data/improvements.json")
+
+	var submitted struct {
+		OK             bool     `json:"ok"`
+		RunID          string   `json:"runId"`
+		ThinkingBlocks int      `json:"thinkingBlocks"`
+		ThinkingChars  int      `json:"thinkingChars"`
+		Iterations     int      `json:"iterations"`
+		Truncated      []string `json:"truncated"`
+	}
+	if status := postJSON(t, base+"/api/submit-trace", traceBody, &submitted); status != http.StatusCreated {
+		t.Fatalf("submit-trace = %d, want 201", status)
+	}
+	if !submitted.OK || submitted.RunID != "run-abc-123" || submitted.ThinkingBlocks != 2 || submitted.Iterations != 2 {
+		t.Errorf("unexpected acknowledgement: %+v", submitted)
+	}
+	if submitted.ThinkingChars == 0 || len(submitted.Truncated) != 0 {
+		t.Errorf("expected a full, untruncated trace: %+v", submitted)
+	}
+
+	_, sitesAfter := getRaw(t, base+"/data/sites.json")
+	_, improvementsAfter := getRaw(t, base+"/data/improvements.json")
+	if sitesAfter != sitesBefore {
+		t.Errorf("a trace changed /data/sites.json:\nbefore %s\nafter  %s", sitesBefore, sitesAfter)
+	}
+	if improvementsAfter != improvementsBefore {
+		t.Errorf("a trace changed /data/improvements.json:\nbefore %s\nafter  %s", improvementsBefore, improvementsAfter)
+	}
+	// And nothing from the reasoning is anywhere in either document.
+	for _, document := range []string{sitesAfter, improvementsAfter} {
+		for _, leak := range []string{"noise floor", "font swap", "thinking", "run-abc-123", "chain of thought"} {
+			if strings.Contains(strings.ToLower(document), strings.ToLower(leak)) {
+				t.Errorf("public JSON leaks %q: %s", leak, document)
+			}
+		}
+	}
+
+	// It is on disk, private, and complete.
+	documents := storedDocuments(t, dir)
+	if len(documents) != 1 {
+		t.Fatalf("expected 1 stored document, got %d", len(documents))
+	}
+	if !strings.Contains(documents[0], "noise floor") || !strings.Contains(documents[0], "Preload the hero image") {
+		t.Errorf("the stored document is missing the trace: %s", documents[0])
+	}
+
+	// And indexed, with the metadata that lets a training set line a trace up
+	// with the run and the board row it came from.
+	var row struct {
+		source, product, prURL, agent, model, path string
+		blocks, chars, iterations, round           int
+		resultsSubmitted                           bool
+		hasResults, hasDiff                        bool
+	}
+	err := pool.QueryRow(`SELECT source, product, pr_url, agent, model, path, thinking_blocks,
+			thinking_chars, iterations, round, results_submitted, has_results, has_diff
+		FROM traces WHERE run_id = ?`, "run-abc-123").Scan(&row.source, &row.product, &row.prURL,
+		&row.agent, &row.model, &row.path, &row.blocks, &row.chars, &row.iterations, &row.round,
+		&row.resultsSubmitted, &row.hasResults, &row.hasDiff)
+	if err != nil {
+		t.Fatalf("read the trace index: %v", err)
+	}
+	if row.source != "cli" || row.product != "Speedy" || row.agent != "cursor" || row.model != "claude-fable-5" {
+		t.Errorf("unexpected index row: %+v", row)
+	}
+	if row.blocks != 2 || row.iterations != 2 || row.round != 1 || !row.resultsSubmitted || !row.hasResults || row.hasDiff {
+		t.Errorf("unexpected index counts: %+v", row)
+	}
+	if !strings.HasSuffix(row.path, "run-abc-123.json") {
+		t.Errorf("path should name the run: %q", row.path)
+	}
+}
+
+// There is no way to read a trace back over HTTP, and the routes that do not
+// exist say so rather than answering with the SPA shell.
+func TestTracesHaveNoPublicRoute(t *testing.T) {
+	server, dir := bootWithTraces(t, freshDatabase(t))
+	base := server.URL
+
+	if status := postJSON(t, base+"/api/submit-trace", traceBody, nil); status != http.StatusCreated {
+		t.Fatalf("submit-trace = %d, want 201", status)
+	}
+	stored := storedDocuments(t, dir)
+	if len(stored) != 1 {
+		t.Fatalf("expected the trace to be stored, got %d documents", len(stored))
+	}
+
+	for _, path := range []string{"/api/submit-trace", "/api/traces", "/api/traces/run-abc-123", "/data/traces.json"} {
+		status, body := getRaw(t, base+path)
+		if status != http.StatusNotFound {
+			t.Errorf("GET %s = %d, want 404", path, status)
+		}
+		if strings.Contains(body, "noise floor") || strings.Contains(body, "<app-root>") {
+			t.Errorf("GET %s should be a plain 404, got %s", path, body)
+		}
+	}
+
+	// The vault is not under the static root, so it cannot be reached as a file
+	// even if someone guesses the layout.
+	status, _ := getRaw(t, base+"/traces/run-abc-123.json")
+	if status != http.StatusNotFound {
+		t.Errorf("GET /traces/... = %d, want 404", status)
+	}
+}
+
+// A client that sends a tool transcript is refused with the reason, rather than
+// having it quietly stripped: a trace that silently is not what it says it is
+// would be worse than no trace.
+func TestSubmitTraceRefusesToolTranscripts(t *testing.T) {
+	server, dir := bootWithTraces(t, freshDatabase(t))
+	base := server.URL
+
+	cases := map[string]string{
+		"top-level messages":         `{"thinking":[{"text":"thought"}],"messages":[{"role":"tool","content":"1000 lines of yarn build"}]}`,
+		"tool results":               `{"thinking":[{"text":"thought"}],"toolResults":[{"output":"…"}]}`,
+		"a build log":                `{"thinking":[{"text":"thought"}],"stdout":"webpack compiled with 4 warnings"}`,
+		"a tool_result block":        `{"thinking":[{"type":"tool_result","text":"total 4816\ndrwxr-xr-x"}]}`,
+		"tool output inside a block": `{"thinking":[{"text":"thought","stdout":"yarn build output"}]}`,
+	}
+	for name, body := range cases {
+		var rejected struct {
+			OK     bool     `json:"ok"`
+			Errors []string `json:"errors"`
+		}
+		status := postJSON(t, base+"/api/submit-trace", body, &rejected)
+		if status != http.StatusBadRequest {
+			t.Errorf("%s: got %d, want 400", name, status)
+			continue
+		}
+		if rejected.OK || !strings.Contains(strings.ToLower(strings.Join(rejected.Errors, " ")), "thinking text only") {
+			t.Errorf("%s: expected an explanation, got %+v", name, rejected)
+		}
+	}
+
+	// An empty trace is refused too, and none of the above wrote anything.
+	if status := postJSON(t, base+"/api/submit-trace", `{"thinking":[]}`, nil); status != http.StatusBadRequest {
+		t.Errorf("an empty trace = %d, want 400", status)
+	}
+	if documents := storedDocuments(t, dir); len(documents) != 0 {
+		t.Errorf("a refused trace must store nothing, got %d documents", len(documents))
+	}
+}
+
+// The caps are what keep a yarn-build log out even when it arrives as
+// "thinking": oversized blocks are cut, extra blocks are dropped, and a body
+// past the outer wall never gets read at all.
+func TestSubmitTraceClampsOversizedThinking(t *testing.T) {
+	pool := freshDatabase(t)
+	server, dir := bootWithTraces(t, pool)
+	base := server.URL
+
+	blocks := make([]string, 0, 20)
+	blocks = append(blocks, fmt.Sprintf(`{"text":%q}`, strings.Repeat("y", trace.MaxBlockChars+500)))
+	for i := 0; i < 19; i++ {
+		blocks = append(blocks, fmt.Sprintf(`{"text":"thought %d"}`, i))
+	}
+	var submitted struct {
+		ThinkingBlocks int      `json:"thinkingBlocks"`
+		ThinkingChars  int      `json:"thinkingChars"`
+		Truncated      []string `json:"truncated"`
+	}
+	body := `{"runId":"clamped","thinking":[` + strings.Join(blocks, ",") + `]}`
+	if status := postJSON(t, base+"/api/submit-trace", body, &submitted); status != http.StatusCreated {
+		t.Fatalf("submit-trace = %d, want 201", status)
+	}
+	if submitted.ThinkingBlocks != 20 {
+		t.Errorf("blocks: got %d, want 20", submitted.ThinkingBlocks)
+	}
+	if len(submitted.Truncated) == 0 || !strings.Contains(strings.Join(submitted.Truncated, " "), "per-block cap") {
+		t.Errorf("expected the response to admit the truncation, got %+v", submitted.Truncated)
+	}
+	documents := storedDocuments(t, dir)
+	if len(documents) != 1 {
+		t.Fatalf("expected 1 document, got %d", len(documents))
+	}
+	var stored trace.Trace
+	if err := json.Unmarshal([]byte(documents[0]), &stored); err != nil {
+		t.Fatalf("decode the stored document: %v", err)
+	}
+	if length := len([]rune(stored.Thinking[0].Text)); length <= trace.MaxBlockChars || length > trace.MaxBlockChars+40 {
+		t.Errorf("the long block stored %d characters, want the cap plus a truncation marker", length)
+	}
+
+	// The outer wall: a body past the trace limit is refused before anything is
+	// parsed, so no amount of "thinking" can carry a real build log.
+	huge := fmt.Sprintf(`{"runId":"huge","thinking":[{"text":%q}]}`, strings.Repeat("z", 600*1024))
+	res, err := http.Post(base+"/api/submit-trace", "application/json", strings.NewReader(huge))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	res.Body.Close()
+	if res.StatusCode != http.StatusRequestEntityTooLarge {
+		t.Errorf("an oversized trace = %d, want 413", res.StatusCode)
+	}
+}
+
+// One run, one trace: a resubmission replaces its own document instead of
+// adding a second copy of the same reasoning to the training set.
+func TestSubmitTraceResubmissionReplacesRatherThanDuplicates(t *testing.T) {
+	pool := freshDatabase(t)
+	server, dir := bootWithTraces(t, pool)
+	base := server.URL
+
+	if status := postJSON(t, base+"/api/submit-trace", traceBody, nil); status != http.StatusCreated {
+		t.Fatalf("first submit = %d, want 201", status)
+	}
+	second := `{"runId":"run-abc-123","agent":"cursor","thinking":[{"text":"the second attempt, with more reasoning"}]}`
+	if status := postJSON(t, base+"/api/submit-trace", second, nil); status != http.StatusOK {
+		t.Fatalf("second submit = %d, want 200", status)
+	}
+
+	documents := storedDocuments(t, dir)
+	if len(documents) != 1 {
+		t.Fatalf("expected 1 document after a resubmission, got %d", len(documents))
+	}
+	if !strings.Contains(documents[0], "the second attempt") || strings.Contains(documents[0], "noise floor") {
+		t.Errorf("the resubmission should have replaced the document: %s", documents[0])
+	}
+	var rows int
+	if err := pool.QueryRow("SELECT COUNT(*) FROM traces").Scan(&rows); err != nil {
+		t.Fatalf("count traces: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("index rows: got %d, want 1", rows)
+	}
+}
+
+// A deployment that collects no traces says so, and the CLI's question is the
+// only thing that would ever have asked.
+func TestSubmitTraceIsUnavailableWithoutATraceDirectory(t *testing.T) {
+	base := boot(t, freshDatabase(t)).URL
+
+	var refused struct {
+		OK     bool     `json:"ok"`
+		Errors []string `json:"errors"`
+	}
+	if status := postJSON(t, base+"/api/submit-trace", traceBody, &refused); status != http.StatusServiceUnavailable {
+		t.Fatalf("submit-trace with no vault = %d, want 503", status)
+	}
+	if refused.OK || !strings.Contains(strings.Join(refused.Errors, " "), "MAKEFASTER_TRACE_DIR") {
+		t.Errorf("expected the 503 to name the setting, got %+v", refused)
+	}
+}

--- a/backend/internal/trace/packed.go
+++ b/backend/internal/trace/packed.go
@@ -1,0 +1,357 @@
+package trace
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// A packed run is one directory per run, in the layout Speed Lab already writes
+// when it exports a session:
+//
+//	<run>/meta.json      required — product, prUrl, agent, model, timestamps
+//	<run>/thinking.jsonl required — one {"text": "…"} object per line, in order
+//	<run>/results.json   optional — the run's results.json
+//	<run>/diff.patch     optional — the unified patch, size-capped on import
+//
+// A backfill is a directory of those directories, or a tar (optionally gzipped)
+// of the same tree. Nothing about the layout goes through the TUI, so a box can
+// be filled from an scp without a single interactive run — and the caps and the
+// whitelisting are the same ones POST /api/submit-trace applies, because the
+// import produces the same Trace value.
+const (
+	metaFile     = "meta.json"
+	thinkingFile = "thinking.jsonl"
+	resultsFile  = "results.json"
+	diffFile     = "diff.patch"
+)
+
+// maxPackedFileBytes is the ceiling on any single file inside a packed run.
+// It is generous next to the trace caps on purpose: a file may be larger than
+// what survives clamping, but it may not be a gigabyte.
+const maxPackedFileBytes = 8 << 20
+
+// packedMeta is the recognised content of meta.json. Unknown keys are ignored,
+// so an exporter that records more than this does not have to be changed.
+type packedMeta struct {
+	RunID            string `json:"runId"`
+	Run              string `json:"run"`
+	Product          string `json:"product"`
+	Site             string `json:"site"`
+	PRURL            string `json:"prUrl"`
+	PR               string `json:"pr"`
+	Agent            string `json:"agent"`
+	Provider         string `json:"provider"`
+	Model            string `json:"model"`
+	Round            int    `json:"round"`
+	StartedAt        string `json:"startedAt"`
+	SubmittedAt      string `json:"submittedAt"`
+	FinishedAt       string `json:"finishedAt"`
+	ResultsSubmitted bool   `json:"resultsSubmitted"`
+}
+
+// packedRun is the raw bytes of one run's files, from a directory or a tar.
+type packedRun struct {
+	Name     string
+	Meta     []byte
+	Thinking []byte
+	Results  []byte
+	Diff     []byte
+}
+
+// LoadDir reads every packed run directly beneath root, in name order.
+func LoadDir(root string) ([]Trace, error) {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", root, err)
+	}
+
+	// A single run directory handed over directly is also accepted: it is what
+	// someone re-importing one export will type.
+	if fileExists(filepath.Join(root, metaFile)) || fileExists(filepath.Join(root, thinkingFile)) {
+		run, err := readRunDir(root, filepath.Base(strings.TrimSuffix(root, string(filepath.Separator))))
+		if err != nil {
+			return nil, err
+		}
+		trace, err := run.trace()
+		if err != nil {
+			return nil, err
+		}
+		return []Trace{trace}, nil
+	}
+
+	traces := []Trace{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		run, err := readRunDir(filepath.Join(root, entry.Name()), entry.Name())
+		if err != nil {
+			return nil, err
+		}
+		if run == nil {
+			continue
+		}
+		trace, err := run.trace()
+		if err != nil {
+			return nil, err
+		}
+		traces = append(traces, trace)
+	}
+	return traces, nil
+}
+
+func readRunDir(dir, name string) (*packedRun, error) {
+	run := &packedRun{Name: name}
+	var err error
+	if run.Meta, err = readCapped(filepath.Join(dir, metaFile)); err != nil {
+		return nil, err
+	}
+	if run.Thinking, err = readCapped(filepath.Join(dir, thinkingFile)); err != nil {
+		return nil, err
+	}
+	if run.Results, err = readCapped(filepath.Join(dir, resultsFile)); err != nil {
+		return nil, err
+	}
+	if run.Diff, err = readCapped(filepath.Join(dir, diffFile)); err != nil {
+		return nil, err
+	}
+	if run.Meta == nil && run.Thinking == nil {
+		return nil, nil // not a packed run, just a directory that happened to be here
+	}
+	return run, nil
+}
+
+// LoadTar reads packed runs from a tar or tar.gz stream. The first path segment
+// of each entry is the run, so both `tar -cf runs.tar run-*/` and a tar with a
+// wrapping directory import the same way.
+func LoadTar(reader io.Reader, gzipped bool) ([]Trace, error) {
+	if gzipped {
+		unzipped, err := gzip.NewReader(reader)
+		if err != nil {
+			return nil, fmt.Errorf("read gzip: %w", err)
+		}
+		defer unzipped.Close()
+		reader = unzipped
+	}
+
+	runs := map[string]*packedRun{}
+	archive := tar.NewReader(reader)
+	for {
+		header, err := archive.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read tar: %w", err)
+		}
+		if header.Typeflag != tar.TypeReg {
+			continue
+		}
+		cleaned := path.Clean(header.Name)
+		if strings.HasPrefix(cleaned, "..") || path.IsAbs(cleaned) {
+			return nil, fmt.Errorf("refusing tar entry outside the archive: %s", header.Name)
+		}
+		runName, file := path.Split(cleaned)
+		runName = strings.Trim(runName, "/")
+		if runName == "" {
+			continue // a loose file at the archive root belongs to no run
+		}
+		switch file {
+		case metaFile, thinkingFile, resultsFile, diffFile:
+		default:
+			continue
+		}
+
+		contents, err := io.ReadAll(io.LimitReader(archive, maxPackedFileBytes+1))
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", cleaned, err)
+		}
+		if len(contents) > maxPackedFileBytes {
+			return nil, fmt.Errorf("%s is larger than the %d byte per-file cap", cleaned, maxPackedFileBytes)
+		}
+
+		run := runs[runName]
+		if run == nil {
+			run = &packedRun{Name: path.Base(runName)}
+			runs[runName] = run
+		}
+		switch file {
+		case metaFile:
+			run.Meta = contents
+		case thinkingFile:
+			run.Thinking = contents
+		case resultsFile:
+			run.Results = contents
+		case diffFile:
+			run.Diff = contents
+		}
+	}
+
+	names := make([]string, 0, len(runs))
+	for name := range runs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	traces := []Trace{}
+	for _, name := range names {
+		trace, err := runs[name].trace()
+		if err != nil {
+			return nil, err
+		}
+		traces = append(traces, trace)
+	}
+	return traces, nil
+}
+
+// trace turns one packed run into the same validated value POST
+// /api/submit-trace produces, so an imported trace and a submitted one are
+// stored identically and clamped by identical rules.
+func (r *packedRun) trace() (Trace, error) {
+	var meta packedMeta
+	if len(r.Meta) > 0 {
+		if err := json.Unmarshal(r.Meta, &meta); err != nil {
+			return Trace{}, fmt.Errorf("%s/%s: %w", r.Name, metaFile, err)
+		}
+	}
+
+	blocks, err := readThinkingJSONL(r.Thinking)
+	if err != nil {
+		return Trace{}, fmt.Errorf("%s/%s: %w", r.Name, thinkingFile, err)
+	}
+
+	results, err := decodePackedResults(r.Results)
+	if err != nil {
+		return Trace{}, fmt.Errorf("%s/%s: %w", r.Name, resultsFile, err)
+	}
+	if len(blocks) == 0 && results.Empty() {
+		return Trace{}, fmt.Errorf("%s: neither %s nor %s carried anything to store", r.Name, thinkingFile, resultsFile)
+	}
+
+	trace := Trace{
+		RunID:            truncate(firstNonEmpty(meta.RunID, meta.Run, r.Name), maxRunID),
+		Source:           SourceImport,
+		Product:          truncate(firstNonEmpty(meta.Product, meta.Site), maxProduct),
+		PRURL:            truncate(firstNonEmpty(meta.PRURL, meta.PR), maxPRURL),
+		Agent:            truncate(firstNonEmpty(meta.Agent, meta.Provider), maxAgent),
+		Model:            truncate(meta.Model, maxModel),
+		Round:            meta.Round,
+		StartedAt:        timestamp(meta.StartedAt),
+		SubmittedAt:      timestamp(firstNonEmpty(meta.SubmittedAt, meta.FinishedAt)),
+		ReceivedAt:       time.Now().UTC().Format(time.RFC3339Nano),
+		ResultsSubmitted: meta.ResultsSubmitted,
+		Results:          results,
+	}
+
+	var notes []string
+	trace.Thinking, notes = clampBlocks(blocks)
+	diff, diffNotes := clampDiff(string(r.Diff))
+	trace.Diff = diff
+	notes = append(notes, diffNotes...)
+	notes = append(notes, clampResults(trace.Results)...)
+	trace.Truncated = dedupe(notes)
+	if trace.Results.Empty() {
+		trace.Results = nil
+	}
+	return trace, nil
+}
+
+// readThinkingJSONL reads thinking.jsonl: one block per line, in order. A line
+// may be a JSON object with a `text` (what the CLI's own
+// `.makefaster/thinking-trace.jsonl` writes) or a bare JSON string. A line that
+// carries tool output is refused rather than stripped, exactly as the endpoint
+// refuses one.
+func readThinkingJSONL(contents []byte) ([]Block, error) {
+	if len(contents) == 0 {
+		return nil, nil
+	}
+	blocks := []Block{}
+	for number, line := range strings.Split(string(contents), "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+		if line == "" {
+			continue
+		}
+		var text string
+		if err := json.Unmarshal([]byte(line), &text); err == nil {
+			blocks = append(blocks, Block{Text: text})
+			continue
+		}
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal([]byte(line), &object); err != nil {
+			return nil, fmt.Errorf("line %d is neither a JSON string nor a JSON object", number+1)
+		}
+		for key := range object {
+			if toolTransportKeys[strings.ToLower(key)] {
+				return nil, fmt.Errorf("line %d carries tool output (%s); a trace holds thinking text only", number+1, key)
+			}
+		}
+		var blockType string
+		_ = json.Unmarshal(object["type"], &blockType)
+		if toolBlockTypes[strings.ToLower(strings.TrimSpace(blockType))] {
+			return nil, fmt.Errorf("line %d is a %s block; a trace holds thinking text only", number+1, blockType)
+		}
+		var blockText string
+		if len(object["text"]) > 0 {
+			_ = json.Unmarshal(object["text"], &blockText)
+		} else if len(object["thinking"]) > 0 {
+			_ = json.Unmarshal(object["thinking"], &blockText)
+		}
+		blocks = append(blocks, Block{Text: blockText})
+	}
+	return blocks, nil
+}
+
+// decodePackedResults reads a whole results.json through the same field-by-field
+// whitelist the endpoint uses, so a packed run's `notes` and anything else the
+// skill wrote for itself stay on Speed Lab's disk rather than entering the
+// training set.
+func decodePackedResults(contents []byte) (*Results, error) {
+	if len(strings.TrimSpace(string(contents))) == 0 {
+		return &Results{}, nil
+	}
+	return decodeResults(json.RawMessage(contents))
+}
+
+func readCapped(path string) ([]byte, error) {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return nil, nil
+	}
+	if info.Size() > maxPackedFileBytes {
+		return nil, fmt.Errorf("%s is larger than the %d byte per-file cap", path, maxPackedFileBytes)
+	}
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	return contents, nil
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/backend/internal/trace/payload.go
+++ b/backend/internal/trace/payload.go
@@ -1,0 +1,274 @@
+package trace
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ValidationError is a rejected trace: the messages are returned verbatim as
+// the `errors` array of a 400 response.
+type ValidationError struct {
+	Errors []string
+}
+
+func (e *ValidationError) Error() string { return strings.Join(e.Errors, "; ") }
+
+func invalid(errors ...string) *ValidationError { return &ValidationError{Errors: errors} }
+
+// toolTransportKeys are the fields a client would use to send a tool
+// transcript, a build log, or the contents of a file. None of them is part of a
+// trace, and a payload carrying one is not a client that needs its trace
+// trimmed — it is a client sending the wrong thing, so it is refused with the
+// reason rather than quietly stripped.
+var toolTransportKeys = map[string]bool{
+	"messages":     true,
+	"conversation": true,
+	"transcript":   true,
+	"toolcalls":    true,
+	"tool_calls":   true,
+	"tooluse":      true,
+	"tool_use":     true,
+	"toolresults":  true,
+	"tool_results": true,
+	"toolresult":   true,
+	"tool_result":  true,
+	"toolouput":    true,
+	"tooloutput":   true,
+	"tool_output":  true,
+	"events":       true,
+	"stdout":       true,
+	"stderr":       true,
+	"logs":         true,
+	"buildlog":     true,
+	"build_log":    true,
+	"output":       true,
+	"outputs":      true,
+	"files":        true,
+	"filecontents": true,
+}
+
+// toolBlockTypes are the block `type` values that mean "this is not a thought".
+var toolBlockTypes = map[string]bool{
+	"tool_use":          true,
+	"tooluse":           true,
+	"tool_result":       true,
+	"toolresult":        true,
+	"tool_call":         true,
+	"toolcall":          true,
+	"function_call":     true,
+	"function_response": true,
+	"tool":              true,
+}
+
+// DecodeSubmission validates a POST /api/submit-trace body:
+//
+//	{ runId?, product?, prUrl?, agent?, model?, round?, startedAt?,
+//	  submittedAt?, resultsSubmitted?, diff?,
+//	  thinking: [{ text } | "…"],
+//	  results?: { northStar?, baseline?, final?, iterations? } }
+//
+// Every field is read by name. `thinking` is read for text; `results` is read
+// into Results field by field. Anything else a client sends is not stored —
+// and a client that sends a tool transcript is told so, because the alternative
+// is a trace that silently is not what it claims to be.
+//
+// The runId is the client's when it gave one and the server's when it did not,
+// so every stored trace has a name and a resubmission of the same run replaces
+// its own trace rather than adding a copy.
+func DecodeSubmission(body []byte, now time.Time) (Trace, error) {
+	var raw map[string]json.RawMessage
+	decoder := json.NewDecoder(strings.NewReader(strings.TrimSpace(string(body))))
+	if err := decoder.Decode(&raw); err != nil || raw == nil {
+		return Trace{}, invalid("payload must be a JSON object")
+	}
+	if decoder.More() {
+		return Trace{}, invalid("body must be valid JSON")
+	}
+
+	var refused []string
+	for key := range raw {
+		if toolTransportKeys[strings.ToLower(key)] {
+			refused = append(refused, key)
+		}
+	}
+	if len(refused) > 0 {
+		return Trace{}, invalid(fmt.Sprintf(
+			"a trace carries the agent's thinking text only; %s is a tool transcript and is not accepted",
+			strings.Join(sorted(refused), ", ")))
+	}
+
+	blocks, err := decodeBlocks(raw["thinking"])
+	if err != nil {
+		return Trace{}, err
+	}
+
+	results, err := decodeResults(raw["results"])
+	if err != nil {
+		return Trace{}, err
+	}
+
+	if len(blocks) == 0 && results.Empty() {
+		return Trace{}, invalid("thinking must be a non-empty array of reasoning blocks")
+	}
+
+	trace := Trace{
+		RunID:            truncate(stringField(raw, "runId"), maxRunID),
+		Source:           SourceCLI,
+		Product:          truncate(stringField(raw, "product"), maxProduct),
+		PRURL:            truncate(stringField(raw, "prUrl", "pr"), maxPRURL),
+		Agent:            truncate(stringField(raw, "agent", "provider"), maxAgent),
+		Model:            truncate(stringField(raw, "model"), maxModel),
+		Round:            intField(raw, "round"),
+		StartedAt:        timestamp(stringField(raw, "startedAt")),
+		SubmittedAt:      timestamp(stringField(raw, "submittedAt")),
+		ReceivedAt:       now.UTC().Format(time.RFC3339Nano),
+		ResultsSubmitted: boolField(raw, "resultsSubmitted"),
+		Results:          results,
+	}
+	if trace.RunID == "" {
+		trace.RunID = NewRunID()
+	}
+
+	var notes []string
+	trace.Thinking, notes = clampBlocks(blocks)
+
+	diff, diffNotes := clampDiff(stringField(raw, "diff"))
+	trace.Diff = diff
+	notes = append(notes, diffNotes...)
+	notes = append(notes, clampResults(trace.Results)...)
+	trace.Truncated = dedupe(notes)
+	if trace.Results.Empty() {
+		trace.Results = nil
+	}
+	return trace, nil
+}
+
+// decodeBlocks reads `thinking`. A block may be a bare string or an object with
+// a `text` — both shapes appear in the wild — and nothing else in the object is
+// read. A block that announces itself as a tool call or a tool result is
+// refused, for the same reason a tool transcript at the top level is.
+func decodeBlocks(field json.RawMessage) ([]Block, error) {
+	if len(field) == 0 {
+		return nil, nil
+	}
+	var entries []json.RawMessage
+	if err := json.Unmarshal(field, &entries); err != nil {
+		return nil, invalid("thinking must be an array of reasoning blocks")
+	}
+
+	blocks := make([]Block, 0, len(entries))
+	for i, entry := range entries {
+		var text string
+		if err := json.Unmarshal(entry, &text); err == nil {
+			blocks = append(blocks, Block{Text: text})
+			continue
+		}
+
+		var object map[string]json.RawMessage
+		if err := json.Unmarshal(entry, &object); err != nil {
+			return nil, invalid(fmt.Sprintf("thinking[%d] must be a string or an object with a text field", i))
+		}
+		for key := range object {
+			if toolTransportKeys[strings.ToLower(key)] {
+				return nil, invalid(fmt.Sprintf(
+					"thinking[%d].%s is tool output; a trace carries the agent's thinking text only", i, key))
+			}
+		}
+		var blockType string
+		_ = json.Unmarshal(object["type"], &blockType)
+		if toolBlockTypes[strings.ToLower(strings.TrimSpace(blockType))] {
+			return nil, invalid(fmt.Sprintf(
+				"thinking[%d] is a %s block; a trace carries the agent's thinking text only", i, blockType))
+		}
+
+		var blockText string
+		if len(object["text"]) > 0 {
+			_ = json.Unmarshal(object["text"], &blockText)
+		} else if len(object["thinking"]) > 0 {
+			_ = json.Unmarshal(object["thinking"], &blockText)
+		}
+		blocks = append(blocks, Block{Text: blockText})
+	}
+	return blocks, nil
+}
+
+// decodeResults reads the optional results summary field by field, so the
+// stored document holds the iteration list and both ends of the run and cannot
+// hold anything else — not `notes`, not a log, not a file.
+func decodeResults(field json.RawMessage) (*Results, error) {
+	if len(field) == 0 || string(field) == "null" {
+		return &Results{}, nil
+	}
+	var raw struct {
+		NorthStar  string             `json:"northStar"`
+		Baseline   map[string]Metrics `json:"baseline"`
+		Final      map[string]Metrics `json:"final"`
+		Iterations []Iteration        `json:"iterations"`
+	}
+	if err := json.Unmarshal(field, &raw); err != nil {
+		return nil, invalid("results must be an object with optional northStar, baseline, final and iterations")
+	}
+
+	results := &Results{
+		NorthStar: truncate(raw.NorthStar, maxPhase),
+		Baseline:  raw.Baseline,
+		Final:     raw.Final,
+	}
+	for _, iteration := range raw.Iterations {
+		results.Iterations = append(results.Iterations, Iteration{
+			Name:        truncate(iteration.Name, maxName),
+			Description: truncate(iteration.Description, maxDescr),
+			Kept:        iteration.Kept,
+			DeltaMs:     iteration.DeltaMs,
+			DeltaPct:    iteration.DeltaPct,
+			Phase:       truncate(iteration.Phase, maxPhase),
+			Generic:     iteration.Generic,
+		})
+	}
+	return results, nil
+}
+
+func stringField(raw map[string]json.RawMessage, names ...string) string {
+	for _, name := range names {
+		if len(raw[name]) == 0 {
+			continue
+		}
+		var value string
+		if err := json.Unmarshal(raw[name], &value); err == nil && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}
+
+func intField(raw map[string]json.RawMessage, name string) int {
+	if len(raw[name]) == 0 {
+		return 0
+	}
+	var value float64
+	if err := json.Unmarshal(raw[name], &value); err != nil || value < 0 || value > 1_000_000 {
+		return 0
+	}
+	return int(value)
+}
+
+func boolField(raw map[string]json.RawMessage, name string) bool {
+	if len(raw[name]) == 0 {
+		return false
+	}
+	var value bool
+	_ = json.Unmarshal(raw[name], &value)
+	return value
+}
+
+func sorted(values []string) []string {
+	out := append([]string(nil), values...)
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j] < out[j-1]; j-- {
+			out[j], out[j-1] = out[j-1], out[j]
+		}
+	}
+	return out
+}

--- a/backend/internal/trace/trace.go
+++ b/backend/internal/trace/trace.go
@@ -1,0 +1,230 @@
+// Package trace holds the private reasoning traces a makefaster run may submit
+// after it has answered the results question: the hidden agent's own chain of
+// thought, kept so a small model can be post-trained on how the loop reasons.
+//
+// The whole package is built around one rule: a trace is thinking text and a
+// short record of what was tried, and nothing else. There is no route that
+// serves one, no board that renders one, and nothing here reaches the checklist
+// the CLI imports — the same posture as the private catalog tips, and for a
+// stronger reason: a trace is a user's reasoning about their own repository,
+// handed over once, on purpose.
+//
+// Everything a client sends is whitelisted rather than filtered. `thinking` is
+// read for text and nothing else; `results` is re-read field by field into
+// Results below, so a tool transcript, a build log or a file dump cannot arrive
+// by riding along in a key nobody thought to strip. A client that sends one
+// deliberately is rejected outright (see DecodeSubmission).
+package trace
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+)
+
+// The caps. They are the reason a 40 MB `yarn build` log cannot land here: the
+// HTTP body limit stops the request, and everything that gets past it is
+// clamped to a size that is still a chain of thought.
+const (
+	// MaxBlocks is how many thinking blocks one trace may carry.
+	MaxBlocks = 400
+	// MaxBlockChars is the ceiling on one block. Past this it is a transcript.
+	MaxBlockChars = 8_000
+	// MaxThinkingChars is the ceiling on all blocks together.
+	MaxThinkingChars = 200_000
+	// MaxIterations is how much of the keep/revert list is kept.
+	MaxIterations = 200
+	// MaxDiffBytes caps the unified patch a backfilled run may carry.
+	MaxDiffBytes = 96 * 1024
+
+	maxRunID   = 64
+	maxProduct = 200
+	maxPRURL   = 500
+	maxAgent   = 40
+	maxModel   = 120
+	maxName    = 120
+	maxDescr   = 500
+	maxPhase   = 40
+)
+
+// truncationMarker ends a value that was clamped, so a reader of the stored
+// document can tell a short thought from a cut one.
+const truncationMarker = "\n…[truncated by makefaster]"
+
+// Block is one block of reasoning. Text and only text: there is deliberately
+// no field for a tool call, a tool result, or a file.
+type Block struct {
+	Text string `json:"text"`
+}
+
+// Metrics is one measurement of the north-star metrics, in the shape
+// results.json writes them. Pointers so an absent metric stays absent rather
+// than becoming a zero the training set would read as "0ms".
+type Metrics struct {
+	LCPMs *float64 `json:"lcpMs,omitempty"`
+	TTIMs *float64 `json:"ttiMs,omitempty"`
+	FCPMs *float64 `json:"fcpMs,omitempty"`
+	TBTMs *float64 `json:"tbtMs,omitempty"`
+}
+
+// Iteration is one experiment: what was tried, what it measured, and whether it
+// survived. `Notes` is deliberately absent — that is where the skill puts
+// everything specific to one repository.
+type Iteration struct {
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Kept        *bool    `json:"kept,omitempty"`
+	DeltaMs     *float64 `json:"deltaMs,omitempty"`
+	DeltaPct    *float64 `json:"deltaPct,omitempty"`
+	Phase       string   `json:"phase,omitempty"`
+	Generic     *bool    `json:"generic,omitempty"`
+}
+
+// Results is the distilled results.json a trace may carry: the iteration list
+// with its keep/revert verdicts, and both ends of the run.
+type Results struct {
+	NorthStar  string             `json:"northStar,omitempty"`
+	Baseline   map[string]Metrics `json:"baseline,omitempty"`
+	Final      map[string]Metrics `json:"final,omitempty"`
+	Iterations []Iteration        `json:"iterations,omitempty"`
+}
+
+// Empty reports whether there is nothing worth storing.
+func (r *Results) Empty() bool {
+	return r == nil || (r.NorthStar == "" && len(r.Baseline) == 0 && len(r.Final) == 0 && len(r.Iterations) == 0)
+}
+
+// Trace is one validated submission, and also the exact shape of the JSON
+// document written under the private trace directory.
+type Trace struct {
+	RunID  string `json:"runId"`
+	Source string `json:"source"`
+
+	Product string `json:"product,omitempty"`
+	PRURL   string `json:"prUrl,omitempty"`
+	Agent   string `json:"agent,omitempty"`
+	Model   string `json:"model,omitempty"`
+	Round   int    `json:"round,omitempty"`
+
+	StartedAt   string `json:"startedAt,omitempty"`
+	SubmittedAt string `json:"submittedAt,omitempty"`
+	ReceivedAt  string `json:"receivedAt"`
+
+	// ResultsSubmitted records whether the same run also sent its numbers to
+	// the public boards. Answering no to that and yes to this is a supported
+	// combination, which is why it is stored rather than assumed.
+	ResultsSubmitted bool `json:"resultsSubmitted"`
+
+	Thinking []Block  `json:"thinking"`
+	Results  *Results `json:"results,omitempty"`
+	Diff     string   `json:"diff,omitempty"`
+
+	// Truncated names what had to be clamped to fit the caps, so the stored
+	// document is honest about being a partial record.
+	Truncated []string `json:"truncated,omitempty"`
+}
+
+// ThinkingChars is the total length of the reasoning kept.
+func (t Trace) ThinkingChars() int {
+	total := 0
+	for _, block := range t.Thinking {
+		total += len([]rune(block.Text))
+	}
+	return total
+}
+
+// IterationCount is how much of the keep/revert list survived.
+func (t Trace) IterationCount() int {
+	if t.Results == nil {
+		return 0
+	}
+	return len(t.Results.Iterations)
+}
+
+// clampBlocks applies the three thinking caps in order: per block, then count,
+// then total. It returns the kept blocks and a note for each cap that bit.
+func clampBlocks(blocks []Block) ([]Block, []string) {
+	kept := make([]Block, 0, len(blocks))
+	var notes []string
+	total := 0
+
+	for _, block := range blocks {
+		text := strings.TrimSpace(block.Text)
+		if text == "" {
+			continue
+		}
+		if len(kept) >= MaxBlocks {
+			notes = append(notes, "thinking: blocks past the cap were dropped")
+			break
+		}
+		runes := []rune(text)
+		if len(runes) > MaxBlockChars {
+			runes = runes[:MaxBlockChars]
+			text = string(runes) + truncationMarker
+			notes = append(notes, "thinking: a block was longer than the per-block cap")
+		}
+		if total+len(runes) > MaxThinkingChars {
+			notes = append(notes, "thinking: the total character cap was reached")
+			break
+		}
+		total += len(runes)
+		kept = append(kept, Block{Text: text})
+	}
+	return kept, dedupe(notes)
+}
+
+func clampDiff(diff string) (string, []string) {
+	trimmed := strings.TrimSpace(diff)
+	if len(trimmed) <= MaxDiffBytes {
+		return trimmed, nil
+	}
+	return trimmed[:MaxDiffBytes] + truncationMarker, []string{"diff: truncated to the size cap"}
+}
+
+func clampResults(results *Results) []string {
+	if results == nil || len(results.Iterations) <= MaxIterations {
+		return nil
+	}
+	results.Iterations = results.Iterations[:MaxIterations]
+	return []string{"results: iterations past the cap were dropped"}
+}
+
+func dedupe(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(values))
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}
+
+func truncate(value string, max int) string {
+	value = strings.TrimSpace(value)
+	runes := []rune(value)
+	if len(runes) <= max {
+		return value
+	}
+	return string(runes[:max])
+}
+
+// timestamp normalizes a client-supplied instant. An unparseable one is
+// dropped rather than guessed at: ReceivedAt is always the server's own.
+func timestamp(value string) string {
+	parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(value))
+	if err != nil {
+		return ""
+	}
+	return parsed.UTC().Format(time.RFC3339Nano)
+}
+
+// Document renders the trace as the JSON written to the private directory.
+func (t Trace) Document() ([]byte, error) {
+	return json.MarshalIndent(t, "", "  ")
+}

--- a/backend/internal/trace/trace_test.go
+++ b/backend/internal/trace/trace_test.go
@@ -1,0 +1,410 @@
+package trace_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"makefaster/internal/trace"
+)
+
+func now() time.Time {
+	return time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+}
+
+func decode(t *testing.T, body string) trace.Trace {
+	t.Helper()
+	submission, err := trace.DecodeSubmission([]byte(body), now())
+	if err != nil {
+		t.Fatalf("DecodeSubmission: %v", err)
+	}
+	return submission
+}
+
+func mustReject(t *testing.T, body, wants string) {
+	t.Helper()
+	_, err := trace.DecodeSubmission([]byte(body), now())
+	var validation *trace.ValidationError
+	if !errors.As(err, &validation) {
+		t.Fatalf("expected a validation error for %s, got %v", body, err)
+	}
+	if !strings.Contains(strings.ToLower(validation.Error()), strings.ToLower(wants)) {
+		t.Errorf("error %q does not mention %q", validation.Error(), wants)
+	}
+}
+
+func TestDecodeSubmissionReadsThinkingAndTheIterationList(t *testing.T) {
+	submission := decode(t, `{
+		"runId": "run-1",
+		"product": "Speedy",
+		"prUrl": "https://github.com/jjcm/speedy/pull/3",
+		"agent": "cursor",
+		"model": "claude-fable-5",
+		"round": 2,
+		"startedAt": "2026-08-25T10:00:00.000Z",
+		"resultsSubmitted": true,
+		"thinking": [
+			{"text": "  the hero image is the LCP element  "},
+			"a bare string is a block too",
+			{"thinking": "and so is one that spells the field the other way"},
+			{"text": "   "}
+		],
+		"results": {
+			"northStar": "lcp",
+			"baseline": {"cold": {"lcpMs": 2400}},
+			"final": {"cold": {"lcpMs": 2100}},
+			"iterations": [{"name": "Preload the hero image", "kept": true, "deltaMs": -180, "notes": "src/app/hero.tsx line 42"}]
+		}
+	}`)
+
+	if len(submission.Thinking) != 3 {
+		t.Fatalf("blocks: got %d, want the 3 non-empty ones: %+v", len(submission.Thinking), submission.Thinking)
+	}
+	if submission.Thinking[0].Text != "the hero image is the LCP element" {
+		t.Errorf("blocks are trimmed when they close: %q", submission.Thinking[0].Text)
+	}
+	if submission.RunID != "run-1" || submission.Product != "Speedy" || submission.Agent != "cursor" || submission.Round != 2 {
+		t.Errorf("metadata: %+v", submission)
+	}
+	if submission.Source != trace.SourceCLI {
+		t.Errorf("source: got %q, want %q", submission.Source, trace.SourceCLI)
+	}
+	if !submission.ResultsSubmitted {
+		t.Error("resultsSubmitted should be recorded, because declining the results and sending a trace is a real answer")
+	}
+	if submission.ReceivedAt == "" {
+		t.Error("the server stamps its own receipt time")
+	}
+	if submission.Results == nil || len(submission.Results.Iterations) != 1 || submission.Results.NorthStar != "lcp" {
+		t.Fatalf("results: %+v", submission.Results)
+	}
+
+	// The iteration list is re-read field by field, so a `notes` full of file
+	// paths cannot ride along into the training set.
+	document, err := submission.Document()
+	if err != nil {
+		t.Fatalf("Document: %v", err)
+	}
+	if strings.Contains(string(document), "hero.tsx") || strings.Contains(string(document), "notes") {
+		t.Errorf("the stored document kept an unrecognised field: %s", document)
+	}
+}
+
+func TestDecodeSubmissionNamesAnUnnamedRun(t *testing.T) {
+	first := decode(t, `{"thinking":["a thought"]}`)
+	second := decode(t, `{"thinking":["a thought"]}`)
+	if first.RunID == "" || second.RunID == "" {
+		t.Fatal("every stored trace needs a name")
+	}
+	if first.RunID == second.RunID {
+		t.Error("two unnamed runs must not collide, or one would overwrite the other")
+	}
+}
+
+func TestDecodeSubmissionRefusesToolTranscripts(t *testing.T) {
+	mustReject(t, `{"thinking":["t"],"messages":[{"role":"tool"}]}`, "tool transcript")
+	mustReject(t, `{"thinking":["t"],"toolResults":[]}`, "tool transcript")
+	mustReject(t, `{"thinking":["t"],"stdout":"yarn build"}`, "tool transcript")
+	mustReject(t, `{"thinking":[{"type":"tool_result","text":"…"}]}`, "thinking text only")
+	mustReject(t, `{"thinking":[{"text":"t","stderr":"…"}]}`, "thinking text only")
+	mustReject(t, `{"thinking":[]}`, "non-empty array")
+	mustReject(t, `{"thinking":"not an array"}`, "array of reasoning blocks")
+	mustReject(t, `not json`, "must be a JSON object")
+}
+
+func TestDecodeSubmissionClampsEveryDimension(t *testing.T) {
+	// One oversized block, then more blocks than the cap allows.
+	blocks := []string{fmt.Sprintf("%q", strings.Repeat("y", trace.MaxBlockChars+1000))}
+	for i := 0; i < trace.MaxBlocks+50; i++ {
+		blocks = append(blocks, fmt.Sprintf("%q", fmt.Sprintf("thought %d", i)))
+	}
+	submission := decode(t, `{"runId":"clamped","thinking":[`+strings.Join(blocks, ",")+`]}`)
+
+	if len(submission.Thinking) != trace.MaxBlocks {
+		t.Errorf("blocks: got %d, want the cap of %d", len(submission.Thinking), trace.MaxBlocks)
+	}
+	if length := len([]rune(submission.Thinking[0].Text)); length <= trace.MaxBlockChars || length > trace.MaxBlockChars+40 {
+		t.Errorf("the long block is %d characters, want the cap plus a marker", length)
+	}
+	if submission.ThinkingChars() > trace.MaxThinkingChars {
+		t.Errorf("total characters %d exceeds the cap of %d", submission.ThinkingChars(), trace.MaxThinkingChars)
+	}
+	notes := strings.Join(submission.Truncated, " ")
+	if !strings.Contains(notes, "per-block cap") || !strings.Contains(notes, "past the cap were dropped") {
+		t.Errorf("the trace should say what was clamped, got %+v", submission.Truncated)
+	}
+}
+
+func TestDecodeSubmissionTruncatesADiffAndCapsIterations(t *testing.T) {
+	iterations := make([]string, 0, trace.MaxIterations+10)
+	for i := 0; i < trace.MaxIterations+10; i++ {
+		iterations = append(iterations, fmt.Sprintf(`{"name":"iteration %d","kept":false}`, i))
+	}
+	body := fmt.Sprintf(`{"runId":"big","thinking":["a thought"],"diff":%q,"results":{"iterations":[%s]}}`,
+		strings.Repeat("+", trace.MaxDiffBytes+2000), strings.Join(iterations, ","))
+	submission := decode(t, body)
+
+	if len(submission.Diff) > trace.MaxDiffBytes+64 {
+		t.Errorf("diff: %d bytes, want the cap of %d plus a marker", len(submission.Diff), trace.MaxDiffBytes)
+	}
+	if submission.IterationCount() != trace.MaxIterations {
+		t.Errorf("iterations: got %d, want the cap of %d", submission.IterationCount(), trace.MaxIterations)
+	}
+	notes := strings.Join(submission.Truncated, " ")
+	if !strings.Contains(notes, "diff") || !strings.Contains(notes, "iterations") {
+		t.Errorf("expected the diff and the iteration list to be reported as clamped, got %+v", submission.Truncated)
+	}
+}
+
+func TestVaultStoresOneDocumentPerRunPrivately(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "traces")
+	// A nil pool is the file-only mode: it is what makes this test say something
+	// about the document rather than about MariaDB.
+	vault, err := trace.NewVault(dir, nil, nil)
+	if err != nil {
+		t.Fatalf("NewVault: %v", err)
+	}
+	if info, err := os.Stat(dir); err != nil || info.Mode().Perm() != 0o700 {
+		t.Fatalf("the trace directory must be 0700: %v %v", info, err)
+	}
+
+	submission := decode(t, `{"runId":"run-9","thinking":["a thought worth keeping"]}`)
+	record, err := vault.Save(context.Background(), submission, true)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if !record.Created || record.ThinkingBlocks != 1 {
+		t.Errorf("unexpected record: %+v", record)
+	}
+	if want := now().Format("2006-01") + "/run-9.json"; !strings.HasSuffix(record.Path, "run-9.json") {
+		t.Errorf("path %q should be %q-shaped", record.Path, want)
+	}
+
+	absolute := filepath.Join(dir, filepath.FromSlash(record.Path))
+	info, err := os.Stat(absolute)
+	if err != nil {
+		t.Fatalf("stat the document: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("the document is %o, want 600", info.Mode().Perm())
+	}
+	contents, _ := os.ReadFile(absolute)
+	var stored trace.Trace
+	if err := json.Unmarshal(contents, &stored); err != nil {
+		t.Fatalf("the document must be readable JSON: %v", err)
+	}
+	if len(stored.Thinking) != 1 || stored.Thinking[0].Text != "a thought worth keeping" {
+		t.Errorf("stored: %+v", stored)
+	}
+
+	// A re-import without --replace leaves the document alone, which is what
+	// makes a re-run of an interrupted backfill safe.
+	second := decode(t, `{"runId":"run-9","thinking":["a different thought"]}`)
+	skipped, err := vault.Save(context.Background(), second, false)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if skipped.Created {
+		t.Error("a repeat without replace should report that it stored nothing")
+	}
+	contents, _ = os.ReadFile(absolute)
+	if strings.Contains(string(contents), "a different thought") {
+		t.Error("a skipped save must not have rewritten the document")
+	}
+}
+
+// A run id is client-supplied, so it must not be able to choose where its
+// document lands.
+func TestVaultRefusesToLetARunIDEscapeTheDirectory(t *testing.T) {
+	root := t.TempDir()
+	dir := filepath.Join(root, "traces")
+	vault, err := trace.NewVault(dir, nil, nil)
+	if err != nil {
+		t.Fatalf("NewVault: %v", err)
+	}
+
+	submission := decode(t, `{"runId":"../../etc/passwd","thinking":["a thought"]}`)
+	record, err := vault.Save(context.Background(), submission, true)
+	if err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if strings.Contains(record.Path, "..") || strings.Contains(record.Path, "etc/passwd") {
+		t.Fatalf("path escaped: %q", record.Path)
+	}
+	absolute := filepath.Join(dir, filepath.FromSlash(record.Path))
+	if !strings.HasPrefix(absolute, dir+string(filepath.Separator)) {
+		t.Fatalf("%q is outside %q", absolute, dir)
+	}
+	if _, err := os.Stat(absolute); err != nil {
+		t.Fatalf("the document should still have been written: %v", err)
+	}
+}
+
+func TestNewVaultReportsThatTracesAreOff(t *testing.T) {
+	if _, err := trace.NewVault("", nil, nil); !errors.Is(err, trace.ErrTracesDisabled) {
+		t.Errorf("an empty directory should disable collection, got %v", err)
+	}
+}
+
+// The backfill layout, imported from a directory: one folder per run holding
+// meta.json, thinking.jsonl, and optionally results.json and diff.patch.
+func TestLoadDirImportsPackedRuns(t *testing.T) {
+	root := t.TempDir()
+	writePackedRun(t, filepath.Join(root, "2026-08-01-speedy"), map[string]string{
+		"meta.json": `{"runId":"speedy-1","product":"Speedy","prUrl":"https://github.com/jjcm/speedy/pull/3",
+			"agent":"claude","model":"claude-fable-5","round":1,"startedAt":"2026-08-01T09:00:00Z","resultsSubmitted":true}`,
+		"thinking.jsonl": "{\"text\":\"the hero image is the LCP element\"}\n\"a bare string block\"\n\n{\"text\":\"preloading it beat the noise floor\"}\n",
+		"results.json":   `{"northStar":"lcp","iterations":[{"name":"Preload the hero image","kept":true,"deltaMs":-180,"notes":"src/hero.tsx"}]}`,
+		"diff.patch":     "--- a/index.html\n+++ b/index.html\n@@\n+<link rel=preload>\n",
+	})
+	// A directory that is not a packed run is ignored rather than failing an
+	// otherwise good backfill.
+	if err := os.MkdirAll(filepath.Join(root, "notes"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	writePackedRun(t, filepath.Join(root, "2026-08-02-other"), map[string]string{
+		"meta.json":      `{"product":"Other"}`,
+		"thinking.jsonl": "{\"text\":\"a second run\"}\n",
+	})
+
+	traces, err := trace.LoadDir(root)
+	if err != nil {
+		t.Fatalf("LoadDir: %v", err)
+	}
+	if len(traces) != 2 {
+		t.Fatalf("expected 2 runs, got %d", len(traces))
+	}
+
+	first := traces[0]
+	if first.RunID != "speedy-1" || first.Product != "Speedy" || first.Agent != "claude" || !first.ResultsSubmitted {
+		t.Errorf("metadata: %+v", first)
+	}
+	if first.Source != trace.SourceImport {
+		t.Errorf("source: got %q, want %q", first.Source, trace.SourceImport)
+	}
+	if len(first.Thinking) != 3 {
+		t.Errorf("blocks: got %d, want 3: %+v", len(first.Thinking), first.Thinking)
+	}
+	if first.Results == nil || len(first.Results.Iterations) != 1 {
+		t.Fatalf("results: %+v", first.Results)
+	}
+	if !strings.Contains(first.Diff, "rel=preload") {
+		t.Errorf("diff: %q", first.Diff)
+	}
+	document, _ := first.Document()
+	if strings.Contains(string(document), "hero.tsx") {
+		t.Errorf("an imported run's results.json goes through the same whitelist: %s", document)
+	}
+
+	// A run with no runId in meta.json is named after its directory, so a
+	// re-import of the same export is still one trace rather than two.
+	if traces[1].RunID != "2026-08-02-other" {
+		t.Errorf("second run id: got %q, want the directory name", traces[1].RunID)
+	}
+}
+
+func TestLoadDirRefusesAPackedRunFullOfToolOutput(t *testing.T) {
+	root := t.TempDir()
+	writePackedRun(t, filepath.Join(root, "bad-run"), map[string]string{
+		"meta.json":      `{"runId":"bad"}`,
+		"thinking.jsonl": "{\"text\":\"fine\"}\n{\"stdout\":\"webpack compiled with 4 warnings\"}\n",
+	})
+	_, err := trace.LoadDir(root)
+	if err == nil || !strings.Contains(err.Error(), "thinking text only") {
+		t.Fatalf("expected the import to refuse tool output, got %v", err)
+	}
+}
+
+func TestLoadTarImportsTheSameLayout(t *testing.T) {
+	files := map[string]string{
+		"runs/speedy-1/meta.json":      `{"runId":"speedy-1","product":"Speedy"}`,
+		"runs/speedy-1/thinking.jsonl": "{\"text\":\"one\"}\n{\"text\":\"two\"}\n",
+		"runs/speedy-2/meta.json":      `{"runId":"speedy-2"}`,
+		"runs/speedy-2/thinking.jsonl": "{\"text\":\"three\"}\n",
+		"runs/README.md":               "not part of a run",
+	}
+
+	for _, gzipped := range []bool{false, true} {
+		archive := buildTar(t, files, gzipped)
+		traces, err := trace.LoadTar(bytes.NewReader(archive), gzipped)
+		if err != nil {
+			t.Fatalf("LoadTar(gzipped=%v): %v", gzipped, err)
+		}
+		if len(traces) != 2 {
+			t.Fatalf("gzipped=%v: expected 2 runs, got %d", gzipped, len(traces))
+		}
+		if traces[0].RunID != "speedy-1" || len(traces[0].Thinking) != 2 {
+			t.Errorf("gzipped=%v: first run %+v", gzipped, traces[0])
+		}
+		if traces[1].RunID != "speedy-2" || traces[1].Source != trace.SourceImport {
+			t.Errorf("gzipped=%v: second run %+v", gzipped, traces[1])
+		}
+	}
+}
+
+func TestLoadTarRefusesAnEntryOutsideTheArchive(t *testing.T) {
+	archive := buildTar(t, map[string]string{
+		"../escape/thinking.jsonl": "{\"text\":\"nope\"}\n",
+	}, false)
+	if _, err := trace.LoadTar(bytes.NewReader(archive), false); err == nil {
+		t.Fatal("expected a tar entry outside the archive to be refused")
+	}
+}
+
+func writePackedRun(t *testing.T, dir string, files map[string]string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	for name, contents := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+}
+
+func buildTar(t *testing.T, files map[string]string, gzipped bool) []byte {
+	t.Helper()
+	var buffer bytes.Buffer
+	var writer *tar.Writer
+	var zipper *gzip.Writer
+	if gzipped {
+		zipper = gzip.NewWriter(&buffer)
+		writer = tar.NewWriter(zipper)
+	} else {
+		writer = tar.NewWriter(&buffer)
+	}
+
+	names := make([]string, 0, len(files))
+	for name := range files {
+		names = append(names, name)
+	}
+	for _, name := range names {
+		contents := files[name]
+		header := &tar.Header{Name: name, Mode: 0o600, Size: int64(len(contents)), Typeflag: tar.TypeReg}
+		if err := writer.WriteHeader(header); err != nil {
+			t.Fatalf("tar header %s: %v", name, err)
+		}
+		if _, err := writer.Write([]byte(contents)); err != nil {
+			t.Fatalf("tar write %s: %v", name, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if zipper != nil {
+		if err := zipper.Close(); err != nil {
+			t.Fatalf("close gzip: %v", err)
+		}
+	}
+	return buffer.Bytes()
+}

--- a/backend/internal/trace/vault.go
+++ b/backend/internal/trace/vault.go
@@ -1,0 +1,287 @@
+package trace
+
+import (
+	"context"
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Where a trace came from.
+const (
+	SourceCLI    = "cli"    // POST /api/submit-trace, on an explicit yes
+	SourceImport = "import" // a backfill of already-packed runs (cmd/traces)
+)
+
+// Vault is the private store: one JSON document per run under a directory no
+// HTTP route serves, plus a row in the `traces` index so the set can be
+// queried without reading every file.
+//
+// The directory is created 0700 and the documents 0600. That is not decoration:
+// the box also serves a public SPA out of FRONTEND_DIR, and the one thing that
+// must never happen to a trace is being served.
+type Vault struct {
+	dir    string
+	db     *sql.DB
+	logger *slog.Logger
+}
+
+// Record is what a save produced: enough to acknowledge the submission without
+// telling the client anything about the server's filesystem.
+type Record struct {
+	RunID          string
+	Path           string
+	Created        bool
+	ThinkingBlocks int
+	ThinkingChars  int
+	Iterations     int
+	Truncated      []string
+}
+
+// ErrTracesDisabled is returned by NewVault when no directory is configured.
+// It is a supported state, not a misconfiguration: a deployment that does not
+// want to collect traces sets no directory, and the endpoint answers 503.
+var ErrTracesDisabled = errors.New("trace storage is not configured")
+
+// NewVault prepares the directory. A db of nil stores documents without
+// indexing them, which is what a box with no database still supports.
+func NewVault(dir string, db *sql.DB, logger *slog.Logger) (*Vault, error) {
+	if strings.TrimSpace(dir) == "" {
+		return nil, ErrTracesDisabled
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	absolute, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve trace dir: %w", err)
+	}
+	if err := os.MkdirAll(absolute, 0o700); err != nil {
+		return nil, fmt.Errorf("create trace dir %s: %w", absolute, err)
+	}
+	return &Vault{dir: absolute, db: db, logger: logger}, nil
+}
+
+// Dir is the private root, for the log line that says where traces are going.
+func (v *Vault) Dir() string { return v.dir }
+
+// Save writes the document and indexes it.
+//
+// A run that submits twice replaces its own trace rather than adding a second
+// copy to the training set: the document path is derived from the run id, and
+// the index row is keyed on it. `replace` false makes a repeat a no-op instead,
+// which is what a backfill that may be re-run needs.
+func (v *Vault) Save(ctx context.Context, trace Trace, replace bool) (Record, error) {
+	if trace.RunID == "" {
+		trace.RunID = NewRunID()
+	}
+	if trace.Source == "" {
+		trace.Source = SourceCLI
+	}
+	if trace.ReceivedAt == "" {
+		trace.ReceivedAt = time.Now().UTC().Format(time.RFC3339Nano)
+	}
+
+	relative := documentPath(trace)
+	absolute := filepath.Join(v.dir, filepath.FromSlash(relative))
+	record := Record{
+		RunID:          trace.RunID,
+		Path:           relative,
+		ThinkingBlocks: len(trace.Thinking),
+		ThinkingChars:  trace.ThinkingChars(),
+		Iterations:     trace.IterationCount(),
+		Truncated:      trace.Truncated,
+	}
+
+	existed := false
+	if _, err := os.Stat(absolute); err == nil {
+		existed = true
+		if !replace {
+			record.Created = false
+			return record, nil
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(absolute), 0o700); err != nil {
+		return Record{}, fmt.Errorf("create trace dir: %w", err)
+	}
+	document, err := trace.Document()
+	if err != nil {
+		return Record{}, fmt.Errorf("encode trace: %w", err)
+	}
+	if err := writeFileAtomic(absolute, document); err != nil {
+		return Record{}, err
+	}
+
+	created, err := v.index(ctx, trace, relative)
+	if err != nil {
+		return Record{}, err
+	}
+	record.Created = created && !existed
+	return record, nil
+}
+
+// index upserts the catalog row. The document is already on disk at this
+// point, so an index write is not allowed to lose it: the error is returned and
+// the caller answers 500, and the next save for the same run rewrites both.
+func (v *Vault) index(ctx context.Context, trace Trace, relative string) (bool, error) {
+	if v.db == nil {
+		return true, nil
+	}
+	result, err := v.db.ExecContext(ctx, `
+		INSERT INTO traces (run_id, source, product, pr_url, agent, model, round,
+			thinking_blocks, thinking_chars, iterations, has_results, has_diff,
+			results_submitted, path, started_at, submitted_at, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		ON DUPLICATE KEY UPDATE
+			source = VALUES(source), product = VALUES(product), pr_url = VALUES(pr_url),
+			agent = VALUES(agent), model = VALUES(model), round = VALUES(round),
+			thinking_blocks = VALUES(thinking_blocks), thinking_chars = VALUES(thinking_chars),
+			iterations = VALUES(iterations), has_results = VALUES(has_results),
+			has_diff = VALUES(has_diff), results_submitted = VALUES(results_submitted),
+			path = VALUES(path), started_at = VALUES(started_at),
+			submitted_at = VALUES(submitted_at), created_at = VALUES(created_at)`,
+		trace.RunID, trace.Source, trace.Product, trace.PRURL, trace.Agent, trace.Model, trace.Round,
+		len(trace.Thinking), trace.ThinkingChars(), trace.IterationCount(),
+		trace.Results != nil, trace.Diff != "", trace.ResultsSubmitted, relative,
+		nullableTime(trace.StartedAt), nullableTime(trace.SubmittedAt), time.Now().UTC())
+	if err != nil {
+		return false, fmt.Errorf("index trace: %w", err)
+	}
+	// MySQL reports 1 for an insert and 2 for an update through this statement.
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return true, nil // the row is stored; the driver just would not say which way
+	}
+	return affected == 1, nil
+}
+
+// List is the internal catalog read: the index rows, newest first. It is not an
+// endpoint and it is deliberately not the source of anything the CLI reads —
+// the checklist comes from GET /data/improvements.json and nothing else. This
+// exists for `makefaster-traces list`, run on the box by whoever is building a
+// training set.
+func (v *Vault) List(ctx context.Context, limit int) ([]IndexRow, error) {
+	if v.db == nil {
+		return nil, errors.New("no database is configured, so there is no trace index to list")
+	}
+	if limit <= 0 || limit > 1000 {
+		limit = 100
+	}
+	rows, err := v.db.QueryContext(ctx, `
+		SELECT run_id, source, product, agent, model, thinking_blocks, thinking_chars,
+			iterations, results_submitted, path, created_at
+		FROM traces ORDER BY created_at DESC, id DESC LIMIT ?`, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list traces: %w", err)
+	}
+	defer rows.Close()
+
+	out := []IndexRow{}
+	for rows.Next() {
+		var row IndexRow
+		if err := rows.Scan(&row.RunID, &row.Source, &row.Product, &row.Agent, &row.Model,
+			&row.ThinkingBlocks, &row.ThinkingChars, &row.Iterations, &row.ResultsSubmitted,
+			&row.Path, &row.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan trace: %w", err)
+		}
+		out = append(out, row)
+	}
+	return out, rows.Err()
+}
+
+// IndexRow is one row of the private catalog.
+type IndexRow struct {
+	RunID            string
+	Source           string
+	Product          string
+	Agent            string
+	Model            string
+	ThinkingBlocks   int
+	ThinkingChars    int
+	Iterations       int
+	ResultsSubmitted bool
+	Path             string
+	CreatedAt        time.Time
+}
+
+// documentPath is `<yyyy-mm>/<run id>.json`: a month per directory so a year of
+// collection is still listable, and the run id as the name so a resubmission
+// lands on its own document instead of beside it.
+func documentPath(trace Trace) string {
+	stamp := trace.ReceivedAt
+	month := time.Now().UTC().Format("2006-01")
+	if parsed, err := time.Parse(time.RFC3339Nano, stamp); err == nil {
+		month = parsed.UTC().Format("2006-01")
+	}
+	return month + "/" + safeFileName(trace.RunID) + ".json"
+}
+
+var unsafeFileChars = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+// safeFileName keeps a client-supplied run id from choosing where its document
+// lands. Path separators, dots and everything else outside the allowlist are
+// folded away, and an id that reduces to nothing gets a fresh one.
+func safeFileName(runID string) string {
+	cleaned := unsafeFileChars.ReplaceAllString(runID, "-")
+	cleaned = strings.Trim(strings.ReplaceAll(cleaned, "..", "-"), ".-")
+	if len(cleaned) > maxRunID {
+		cleaned = cleaned[:maxRunID]
+	}
+	if cleaned == "" {
+		return NewRunID()
+	}
+	return cleaned
+}
+
+// writeFileAtomic writes 0600 through a temporary file in the same directory,
+// so a reader building a training set never sees a half-written document.
+func writeFileAtomic(path string, contents []byte) error {
+	temp, err := os.CreateTemp(filepath.Dir(path), ".trace-*")
+	if err != nil {
+		return fmt.Errorf("create trace file: %w", err)
+	}
+	name := temp.Name()
+	defer os.Remove(name)
+
+	if err := temp.Chmod(0o600); err != nil {
+		temp.Close()
+		return fmt.Errorf("chmod trace file: %w", err)
+	}
+	if _, err := temp.Write(contents); err != nil {
+		temp.Close()
+		return fmt.Errorf("write trace file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close trace file: %w", err)
+	}
+	if err := os.Rename(name, path); err != nil {
+		return fmt.Errorf("store trace file: %w", err)
+	}
+	return nil
+}
+
+// NewRunID names a trace whose submitter did not name it.
+func NewRunID() string {
+	buffer := make([]byte, 16)
+	if _, err := rand.Read(buffer); err != nil {
+		return fmt.Sprintf("run-%d", time.Now().UTC().UnixNano())
+	}
+	return hex.EncodeToString(buffer)
+}
+
+func nullableTime(value string) any {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return nil
+	}
+	return parsed.UTC()
+}

--- a/env.example
+++ b/env.example
@@ -31,6 +31,20 @@ SEED_DIR=../data
 # The SPA static root. Unknown app paths fall back to its index.html.
 FRONTEND_DIR=../frontend
 
+# --------------------------------------------------------- chains of thought
+
+# Where POST /api/submit-trace stores the reasoning a run chose to hand over,
+# as one 0600 JSON document per run in a 0700 directory. Deliberately outside
+# the repo and outside FRONTEND_DIR: the one thing that must never happen to a
+# trace is being served as a static file. No endpoint reads this back, nothing
+# in it reaches a board or /data/*.json, and it is not where the CLI's imported
+# checklist comes from.
+#
+# Set to "off" (or empty) to collect nothing: the endpoint then answers 503 and
+# the CLI's question simply reports that this deployment does not collect them.
+# The process needs write access to the parent directory.
+# MAKEFASTER_TRACE_DIR=/var/lib/makefaster/traces
+
 # --------------------------------------------------------------- embeddings
 
 # Unset: the deterministic local feature-hashing embedder (no network, no key,

--- a/packages/cli/lib/agents/acp.js
+++ b/packages/cli/lib/agents/acp.js
@@ -18,6 +18,7 @@
 import { createJsonRpcChild } from "../jsonrpc.js";
 import { buildAgentSpawn, isAuthRequiredError } from "../invoke.js";
 import { classifyEvent } from "../progress.js";
+import { thinkingTextOf } from "../thinkingTrace.js";
 
 const ACP_PROTOCOL_VERSION = 1;
 const CLIENT_INFO = { name: "makefaster", version: "1.0.0" };
@@ -54,6 +55,9 @@ export async function runAcpSession({ provider, prompt, cwd, model = null, env =
     label: `${provider.displayName} (acp)`,
     onNotification: (method, params) => {
       if (method !== "session/update") return;
+      // The thought chunk's own text, which the classifier reduces to the word
+      // "thinking" — kept for the trace, shown nowhere.
+      reporter.thought?.(thinkingTextOf("acp", params?.update));
       reporter.update(classifyEvent("acp", params?.update));
     },
     onRequest: (method, params, responder) => {

--- a/packages/cli/lib/agents/claudeCode.js
+++ b/packages/cli/lib/agents/claudeCode.js
@@ -26,6 +26,7 @@ import { spawn } from "node:child_process";
 import { createInterface } from "node:readline";
 import { buildAgentSpawn, claudePrintModeArgs, childEnv, isAuthRequiredError } from "../invoke.js";
 import { classifyEvent } from "../progress.js";
+import { thinkingTextOf } from "../thinkingTrace.js";
 
 const SDK_MODULE = "@anthropic-ai/claude-agent-sdk";
 
@@ -89,6 +90,7 @@ async function runWithSdk({ sdk, provider, prompt, cwd, model, env, reporter, si
   try {
     const session = sdk.query({ prompt: singlePromptIterable(prompt), options });
     for await (const message of session) {
+      reporter.thought?.(thinkingTextOf("claude-stream-json", message));
       reporter.update(classifyEvent("claude-stream-json", message));
     }
     return { exitCode: 0, stderrTail: stderrTail.trim(), aborted: Boolean(signal?.aborted), authRequired: false, path: "sdk" };
@@ -136,7 +138,9 @@ function runWithPrintMode({ provider, prompt, cwd, model, env, reporter, signal 
         const trimmed = line.trim();
         if (trimmed === "") return;
         try {
-          reporter.update(classifyEvent("claude-stream-json", JSON.parse(trimmed)));
+          const event = JSON.parse(trimmed);
+          reporter.thought?.(thinkingTextOf("claude-stream-json", event));
+          reporter.update(classifyEvent("claude-stream-json", event));
         } catch {
           /* not a protocol frame */
         }

--- a/packages/cli/lib/agents/codexAppServer.js
+++ b/packages/cli/lib/agents/codexAppServer.js
@@ -17,6 +17,7 @@
 import { createJsonRpcChild } from "../jsonrpc.js";
 import { buildAgentSpawn, isAuthRequiredError } from "../invoke.js";
 import { classifyEvent } from "../progress.js";
+import { thinkingTextOf } from "../thinkingTrace.js";
 
 const CLIENT_INFO = { name: "makefaster", version: "1.0.0", title: null };
 const INITIALIZE_PARAMS = { clientInfo: CLIENT_INFO, capabilities: { experimentalApi: true } };
@@ -83,6 +84,9 @@ export async function runCodexSession({ provider, prompt, cwd, model = null, env
     env: spawnSpec.options.env,
     label: `${provider.displayName} (app-server)`,
     onNotification: (method, params) => {
+      // Reasoning arrives as deltas the classifier drops as token noise; the
+      // trace keeps the text and the panel still sees nothing.
+      reporter.thought?.(thinkingTextOf("codex-app-server", { method, params }));
       reporter.update(classifyEvent("codex-app-server", { method, params }));
       // The turn is what makefaster waits on: turn/start only acknowledges the
       // dispatch, so completion arrives as a notification.

--- a/packages/cli/lib/agents/openrouter.js
+++ b/packages/cli/lib/agents/openrouter.js
@@ -20,6 +20,7 @@
  *     results.json — the same contract every other provider follows.
  */
 
+import { thinkingTextOf } from "../thinkingTrace.js";
 import { TOOL_SCHEMAS, createTools, describeToolCall } from "./tools.js";
 
 /** The path the server exposes the OpenAI-compatible proxy on. */
@@ -123,6 +124,9 @@ export async function runOpenRouterSession({
     // Assistant prose is not shown anywhere: the panel is the step log. It is
     // kept in the history because it is the model's own reasoning trail.
     messages.push(message);
+    // A reasoning model's thinking for this turn, when the proxy passed one
+    // through — captured for the trace, never displayed, never in the history.
+    reporter?.thought?.(thinkingTextOf("openai-message", message));
     reporter?.update?.({ tag: "EXECUTE", text: labelFor(message) });
 
     const calls = Array.isArray(message.tool_calls) ? message.tool_calls : [];

--- a/packages/cli/lib/apiClient.js
+++ b/packages/cli/lib/apiClient.js
@@ -10,6 +10,14 @@ const MAX_TIPS = 10;
 const TIP_TEXT_MAX = 280;
 const TIP_ABOUT_MAX = 80;
 
+// Trace caps, mirroring the server's. They are the reason a huge build log
+// cannot arrive here: a trace is reasoning text and a short iteration list, and
+// anything past these bounds is dropped before the request is built.
+const MAX_TRACE_BLOCKS = 400;
+const TRACE_BLOCK_MAX = 8_000;
+const TRACE_TOTAL_MAX = 192_000;
+const TRACE_ITERATIONS_MAX = 200;
+
 export function resolveApiBase({ flag, env = process.env } = {}) {
   return (flag || env.MAKEFASTER_API_BASE || DEFAULT_API_BASE).replace(/\/$/, "");
 }
@@ -41,6 +49,10 @@ export function submitSite(apiBase, payload) {
 
 export function submitImprovements(apiBase, payload) {
   return postJson(apiBase, "/api/submit-improvements", payload);
+}
+
+export function submitTrace(apiBase, payload) {
+  return postJson(apiBase, "/api/submit-trace", payload);
 }
 
 function pctChange(baseline, final) {
@@ -160,6 +172,83 @@ export function buildSitePayloads(results, siteUrl) {
  * that says nothing is submitted, which is what every session written before
  * the field existed does.
  */
+/**
+ * The distilled results.json a trace carries: what was tried, in order, and
+ * what the numbers said. Fields are listed one by one rather than spread, for
+ * the same reason `buildImprovementsPayload` does it — an iteration's `notes`
+ * is where the skill puts everything specific to this repo, and a trace is a
+ * record of reasoning, not a place for it to arrive by accident.
+ */
+function traceResults(results) {
+  if (!results || results.parseError) return null;
+  const iterations = (results.iterations || [])
+    .filter((it) => it && typeof it === "object")
+    .slice(0, TRACE_ITERATIONS_MAX)
+    .map((it) => ({
+      ...(it.name ? { name: String(it.name).slice(0, 120) } : {}),
+      ...(it.description ? { description: String(it.description).slice(0, 500) } : {}),
+      ...(typeof it.kept === "boolean" ? { kept: it.kept } : {}),
+      ...(typeof it.deltaMs === "number" ? { deltaMs: it.deltaMs } : {}),
+      ...(typeof it.deltaPct === "number" ? { deltaPct: it.deltaPct } : {}),
+      ...(it.phase ? { phase: String(it.phase).slice(0, 40) } : {}),
+      ...(typeof it.generic === "boolean" ? { generic: it.generic } : {}),
+    }));
+  const payload = {
+    ...(results.northStar ? { northStar: String(results.northStar).slice(0, 40) } : {}),
+    ...(results.baseline && typeof results.baseline === "object" ? { baseline: results.baseline } : {}),
+    ...(results.final && typeof results.final === "object" ? { final: results.final } : {}),
+    ...(iterations.length > 0 ? { iterations } : {}),
+  };
+  return Object.keys(payload).length > 0 ? payload : null;
+}
+
+/**
+ * The chain-of-thought payload for POST /api/submit-trace: the round's thinking
+ * blocks in order, the iteration list, and the metadata that says which run
+ * produced them.
+ *
+ * `thinking` is text and only text. The blocks come from
+ * `.makefaster/thinking-trace.jsonl`, which is written from the provider's
+ * reasoning stream (see lib/thinkingTrace.js) — no tool calls, no tool results,
+ * no file contents, no command output. The caps here are the client half of the
+ * server's: 400 blocks, 8k characters each, ~192k in total, so a session that
+ * thought out loud for an hour still sends a request rather than a log.
+ *
+ * Returns null when there is nothing to send, so the end screen can say so
+ * instead of posting an empty trace.
+ */
+export function buildTracePayload({ blocks, results, state = {}, resultsSubmitted = false, siteUrl = null }) {
+  const thinking = [];
+  let total = 0;
+  for (const block of Array.isArray(blocks) ? blocks : []) {
+    if (thinking.length >= MAX_TRACE_BLOCKS || total >= TRACE_TOTAL_MAX) break;
+    const text = typeof block?.text === "string" ? block.text.trim() : "";
+    if (text === "") continue;
+    const clipped = text.slice(0, Math.min(TRACE_BLOCK_MAX, TRACE_TOTAL_MAX - total));
+    thinking.push({ text: clipped });
+    total += clipped.length;
+  }
+
+  const distilled = traceResults(results);
+  if (thinking.length === 0 && !distilled) return null;
+
+  const product = results?.site?.name || siteUrl || state.siteUrl || results?.site?.url || "";
+  const prUrl = sitePrUrl(results);
+  return {
+    ...(state.runId ? { runId: String(state.runId).slice(0, 64) } : {}),
+    ...(product ? { product: String(product).slice(0, 200) } : {}),
+    ...(prUrl ? { prUrl } : {}),
+    ...(state.provider ? { agent: String(state.provider).slice(0, 40) } : {}),
+    ...(state.model ? { model: String(state.model).slice(0, 120) } : {}),
+    ...(Number.isFinite(state.round) ? { round: state.round } : {}),
+    ...(state.startedAt ? { startedAt: String(state.startedAt).slice(0, 40) } : {}),
+    submittedAt: new Date().toISOString(),
+    resultsSubmitted: Boolean(resultsSubmitted),
+    thinking,
+    ...(distilled ? { results: distilled } : {}),
+  };
+}
+
 export function buildImprovementsPayload(results) {
   const kept = (results?.iterations || [])
     .filter((it) => it && it.kept === true && it.name && it.generic !== false)

--- a/packages/cli/lib/endscreen.js
+++ b/packages/cli/lib/endscreen.js
@@ -1,19 +1,38 @@
 /**
- * The end screen: session summary plus the three questions —
+ * The end screen: session summary plus the questions —
  *   1. Loop more?                        (another round from where it left off)
  *   2. Submit stats to the Site leaderboard?   (URL + favicon are public)
  *   3. Submit anonymous improvements data?     (categories + deltas only)
+ *   4. Submit this session's chain of thought? (private, never published)
+ *
+ * 2 and 3 are one decision in two parts — "upload the results of this run" —
+ * and 4 is a decision of its own, asked only once that one has been answered.
+ * They are not bundled: uploading results and declining the chain of thought is
+ * a normal answer, and so is the reverse. 4 defaults to no and is never
+ * inferred from 2 or 3.
+ *
+ * Prompts and output go through `io` so the sequence is testable without a TTY.
  */
 
 import { writeFileSync } from "node:fs";
 import {
   buildImprovementsPayload,
   buildSitePayloads,
+  buildTracePayload,
   submitImprovements,
   submitSite,
+  submitTrace,
 } from "./apiClient.js";
 import { confirm, question } from "./picker.js";
+import { readThinkingTrace } from "./thinkingTrace.js";
 import { ARROW, FAIL, OK, bold, cyan, dim, formatMs, formatPct, green, hr, red, yellow } from "./ui.js";
+
+/** The real terminal. Tests pass their own. */
+const TERMINAL_IO = {
+  confirm,
+  question,
+  log: (line = "") => console.log(line),
+};
 
 function pctChangeLabel(baseline, final) {
   if (!(baseline > 0) || typeof final !== "number") return "";
@@ -93,120 +112,201 @@ export function renderSummary(results, state) {
   return lines.join("\n");
 }
 
-function savePending(paths, entry) {
+function savePending(paths, entry, io) {
   try {
     writeFileSync(paths.pending, JSON.stringify(entry, null, 2) + "\n");
-    console.log(dim(`  payload saved to ${paths.pending} — resubmit later with the same POST.`));
+    io.log(dim(`  payload saved to ${paths.pending} — resubmit later with the same POST.`));
   } catch {
     /* the payload was already printed in the error path; nothing else to do */
   }
 }
 
-async function askSiteSubmission({ results, state, paths }) {
+/** @returns {Promise<boolean>} whether anything actually reached the board */
+async function askSiteSubmission({ results, state, paths, io }) {
   let siteUrl = state.siteUrl || results?.site?.url || null;
   const payloadsPreview = buildSitePayloads(results || {}, siteUrl || "example.com");
   if (payloadsPreview.length === 0) {
-    console.log(dim("  Site leaderboard: skipped — results.json has no complete cold/warm baseline+final numbers."));
-    return;
+    io.log(dim("  Site leaderboard: skipped — results.json has no complete cold/warm baseline+final numbers."));
+    return false;
   }
 
-  console.log(`  ${bold("2. Submit stats to the Site leaderboard?")}`);
-  console.log(dim("     Your site's URL and favicon will be displayed publicly, with its"));
-  console.log(dim("     measured LCP/TTI and the improvement since baseline."));
+  io.log(`  ${bold("2. Submit stats to the Site leaderboard?")}`);
+  io.log(dim("     Your site's URL and favicon will be displayed publicly, with its"));
+  io.log(dim("     measured LCP/TTI and the improvement since baseline."));
   // Everything else the row will carry, so the answer is informed.
   const preview = payloadsPreview[0];
   if (preview.prUrl) {
-    console.log(dim(`     The row's name will link to ${preview.prUrl}.`));
+    io.log(dim(`     The row's name will link to ${preview.prUrl}.`));
   }
   if (typeof preview.genericKeepPct === "number") {
-    console.log(dim(`     It will also show that ${preview.genericKeepPct}% of what you kept was reusable technique.`));
+    io.log(dim(`     It will also show that ${preview.genericKeepPct}% of what you kept was reusable technique.`));
   }
   // Tips are disclosed as a count only: they are notes to the makefaster
   // maintainers about the catalog, stored privately and never displayed —
   // here or anywhere else.
   if (Array.isArray(preview.tips) && preview.tips.length > 0) {
-    console.log(dim(`     ${preview.tips.length} private catalog note${preview.tips.length === 1 ? "" : "s"} for the makefaster`));
-    console.log(dim("     maintainers ride along. They are never published anywhere."));
+    io.log(dim(`     ${preview.tips.length} private catalog note${preview.tips.length === 1 ? "" : "s"} for the makefaster`));
+    io.log(dim("     maintainers ride along. They are never published anywhere."));
   }
-  const wants = await confirm("     Submit site stats?", { def: false });
-  if (!wants) return;
+  const wants = await io.confirm("     Submit site stats?", { def: false });
+  if (!wants) return false;
 
   if (!siteUrl) {
-    siteUrl = await question("     Site URL (e.g. example.com): ");
+    siteUrl = await io.question("     Site URL (e.g. example.com): ");
   }
   if (!siteUrl) {
-    console.log(yellow("     No URL given — skipping the site submission."));
-    return;
+    io.log(yellow("     No URL given — skipping the site submission."));
+    return false;
   }
 
+  let submitted = false;
   const payloads = buildSitePayloads(results, siteUrl);
   for (const payload of payloads) {
     try {
       const res = await submitSite(state.apiBase, payload);
-      console.log(`     ${OK} ${payload.mode}: ${res.created ? "added to" : "updated on"} the board (${payload.url}, LCP ${formatPct(payload.lcpDelta)})`);
+      submitted = true;
+      io.log(`     ${OK} ${payload.mode}: ${res.created ? "added to" : "updated on"} the board (${payload.url}, LCP ${formatPct(payload.lcpDelta)})`);
     } catch (err) {
-      console.log(`     ${FAIL} ${payload.mode}: ${red(err.message)}`);
-      savePending(paths, { endpoint: "/api/submit-site", apiBase: state.apiBase, payload });
+      io.log(`     ${FAIL} ${payload.mode}: ${red(err.message)}`);
+      savePending(paths, { endpoint: "/api/submit-site", apiBase: state.apiBase, payload }, io);
     }
   }
+  return submitted;
 }
 
-async function askImprovementsSubmission({ results, state, paths }) {
+/** @returns {Promise<boolean>} whether anything actually reached the board */
+async function askImprovementsSubmission({ results, state, paths, io }) {
   const payload = buildImprovementsPayload(results || {});
   if (!payload) {
-    console.log(dim("  Improvements data: skipped — no kept improvements with measured deltas."));
-    return;
+    io.log(dim("  Improvements data: skipped — no kept improvements with measured deltas."));
+    return false;
   }
 
-  console.log(`  ${bold("3. Submit anonymous improvements data?")}`);
-  console.log(dim(`     No URL, no site identity — only what worked (${payload.improvements.length} ` +
+  io.log(`  ${bold("3. Submit anonymous improvements data?")}`);
+  io.log(dim(`     No URL, no site identity — only what worked (${payload.improvements.length} ` +
     `improvement${payload.improvements.length === 1 ? "" : "s"}: name, description, deltas). This`));
-  console.log(dim("     grows the public improvement leaderboard every site learns from."));
-  const wants = await confirm("     Submit anonymous improvements?", { def: false });
-  if (!wants) return;
+  io.log(dim("     grows the public improvement leaderboard every site learns from."));
+  const wants = await io.confirm("     Submit anonymous improvements?", { def: false });
+  if (!wants) return false;
 
   try {
     const res = await submitImprovements(state.apiBase, payload);
     for (const result of res.results || []) {
       const verb = result.action === "created" ? cyan("new category") : `matched ${dim(`(${result.similarity})`)}`;
-      console.log(`     ${OK} ${result.input} ${ARROW} ${bold(result.category)} — ${verb}`);
+      io.log(`     ${OK} ${result.input} ${ARROW} ${bold(result.category)} — ${verb}`);
     }
+    return true;
   } catch (err) {
-    console.log(`     ${FAIL} ${red(err.message)}`);
-    savePending(paths, { endpoint: "/api/submit-improvements", apiBase: state.apiBase, payload });
+    io.log(`     ${FAIL} ${red(err.message)}`);
+    savePending(paths, { endpoint: "/api/submit-improvements", apiBase: state.apiBase, payload }, io);
+    return false;
   }
 }
 
 /**
- * @returns {Promise<{loopMore: boolean}>}
+ * The second decision, asked only after the first has been answered: the
+ * session's chain of thought. The trace spans every round the session ran,
+ * because a session that looped three times reasoned across all three.
+ *
+ * This one is not a leaderboard submission and is disclosed as what it is —
+ * the hidden agent's own reasoning, kept on the makefaster server to post-train
+ * a smaller model on how the loop reasons. It is never published: not on either
+ * board, not in `GET /data/*.json`, and not in the checklist another run
+ * imports. Which is exactly why it defaults to no and takes an explicit yes:
+ * a default of yes would be an upload the user never made.
+ *
+ * @returns {Promise<boolean>} whether a trace was sent
  */
-export async function runEndScreen({ results, state, paths }) {
-  console.log(renderSummary(results, state));
-
-  if (!process.stdin.isTTY) {
-    console.log(dim("  stdin is not a TTY — skipping the end-screen questions (loop more /"));
-    console.log(dim("  submit site stats / submit anonymous improvements). Run makefaster in"));
-    console.log(dim("  a terminal to submit, or POST .makefaster/results.json-derived payloads"));
-    console.log(dim(`  to ${state.apiBase}/api/submit-site and /api/submit-improvements.`));
-    return { loopMore: false };
+async function askTraceSubmission({ results, state, paths, io, resultsSubmitted }) {
+  const blocks = paths.trace ? readThinkingTrace(paths.trace) : [];
+  const payload = buildTracePayload({
+    blocks,
+    results,
+    state,
+    resultsSubmitted,
+    siteUrl: state.siteUrl || results?.site?.url || null,
+  });
+  if (!payload || payload.thinking.length === 0) {
+    io.log(dim("  Chain of thought: skipped — this session captured no reasoning text"));
+    io.log(dim(`  (${state.provider || "the agent"} does not expose one, or the run stopped before it thought).`));
+    return false;
   }
 
-  console.log(`  ${bold("1. Loop more?")}`);
-  console.log(dim(`     Runs another round: anything left of the ${state.checklistCount ?? "?"}-category checklist first,`));
-  console.log(dim(`     then up to ${state.extrasBudget ?? "?"} more hypotheses of the agent's own.`));
-  const loopMore = await confirm("     Keep looping?", { def: false });
-  console.log("");
+  const chars = payload.thinking.reduce((sum, block) => sum + block.text.length, 0);
+  const iterations = payload.results?.iterations?.length ?? 0;
+  io.log(`  ${bold("4. Submit this session's chain of thought?")} ${dim("(separate question, off by default)")}`);
+  io.log(dim(`     ${payload.thinking.length} thinking block${payload.thinking.length === 1 ? "" : "s"} ` +
+    `(${Math.round(chars / 100) / 10}k characters) of ${state.modelLabel || state.model || "the agent"}'s own`));
+  io.log(dim(`     reasoning, in order${iterations > 0 ? `, plus the ${iterations}-iteration keep/revert list` : ""}. Text only:`));
+  io.log(dim("     no tool calls, no command output, no file contents, no diff."));
+  io.log(dim("     Kept privately on the makefaster server to post-train a small model on how"));
+  io.log(dim("     the loop reasons. Never shown on the boards, never served by any endpoint,"));
+  io.log(dim("     and never fed to another run's checklist."));
+  io.log(dim(`     ${paths.trace} is the exact file — read it first if you like.`));
+  const wants = await io.confirm("     Submit the chain of thought?", { def: false });
+  if (!wants) {
+    io.log(dim("     Not submitted. The trace stays in .makefaster/, which git ignores."));
+    return false;
+  }
+
+  try {
+    const res = await submitTrace(state.apiBase, payload);
+    io.log(`     ${OK} trace stored (${res.thinkingBlocks ?? payload.thinking.length} blocks). Thank you — it is not published anywhere.`);
+    return true;
+  } catch (err) {
+    io.log(`     ${FAIL} ${red(err.message)}`);
+    savePending(paths, { endpoint: "/api/submit-trace", apiBase: state.apiBase, payload }, io);
+    return false;
+  }
+}
+
+/**
+ * @param {object} args
+ * @param {object|null} args.results
+ * @param {object} args.state
+ * @param {object} args.paths
+ * @param {{confirm: Function, question: Function, log: Function}} [args.io] test seam
+ * @param {boolean} [args.interactive] test seam for the non-TTY path
+ * @returns {Promise<{loopMore: boolean, resultsSubmitted: boolean, traceSubmitted: boolean}>}
+ */
+export async function runEndScreen({ results, state, paths, io = TERMINAL_IO, interactive = process.stdin.isTTY }) {
+  io.log(renderSummary(results, state));
+
+  if (!interactive) {
+    io.log(dim("  stdin is not a TTY — skipping the end-screen questions (loop more / submit"));
+    io.log(dim("  site stats / submit anonymous improvements / submit the chain of thought)."));
+    io.log(dim("  Run makefaster in a terminal to submit, or POST .makefaster/results.json-derived"));
+    io.log(dim(`  payloads to ${state.apiBase}/api/submit-site and /api/submit-improvements.`));
+    // Deliberately not offered here: a trace is only ever sent on an explicit
+    // yes, and a non-interactive run cannot give one.
+    return { loopMore: false, resultsSubmitted: false, traceSubmitted: false };
+  }
+
+  io.log(`  ${bold("1. Loop more?")}`);
+  io.log(dim(`     Runs another round: anything left of the ${state.checklistCount ?? "?"}-category checklist first,`));
+  io.log(dim(`     then up to ${state.extrasBudget ?? "?"} more hypotheses of the agent's own.`));
+  const loopMore = await io.confirm("     Keep looping?", { def: false });
+  io.log("");
 
   if (loopMore) {
-    // Questions 2 & 3 come around again after the next round's end screen.
-    return { loopMore: true };
+    // Every question below comes around again after the next round's end screen.
+    return { loopMore: true, resultsSubmitted: false, traceSubmitted: false };
   }
 
-  await askSiteSubmission({ results, state, paths });
-  console.log("");
-  await askImprovementsSubmission({ results, state, paths });
-  console.log("");
-  console.log(dim(`  Leaderboards: ${state.apiBase}/site-leaderboard - ${state.apiBase}/improvement-leaderboard`));
-  console.log("");
-  return { loopMore: false };
+  // Decision one: upload the results of this run.
+  const site = await askSiteSubmission({ results, state, paths, io });
+  io.log("");
+  const improvements = await askImprovementsSubmission({ results, state, paths, io });
+  io.log("");
+
+  // Decision two, asked only now that decision one has an answer — and taken on
+  // its own terms: declining the results above does not decline this, and
+  // accepting them does not accept it.
+  const resultsSubmitted = site || improvements;
+  const traceSubmitted = await askTraceSubmission({ results, state, paths, io, resultsSubmitted });
+  io.log("");
+
+  io.log(dim(`  Leaderboards: ${state.apiBase}/site-leaderboard - ${state.apiBase}/improvement-leaderboard`));
+  io.log("");
+  return { loopMore: false, resultsSubmitted, traceSubmitted };
 }

--- a/packages/cli/lib/endscreen.js
+++ b/packages/cli/lib/endscreen.js
@@ -233,12 +233,15 @@ async function askTraceSubmission({ results, state, paths, io, resultsSubmitted 
   }
 
   const chars = payload.thinking.reduce((sum, block) => sum + block.text.length, 0);
+  const size = chars < 1000 ? `${chars} characters` : `${Math.round(chars / 100) / 10}k characters`;
   const iterations = payload.results?.iterations?.length ?? 0;
   io.log(`  ${bold("4. Submit this session's chain of thought?")} ${dim("(separate question, off by default)")}`);
-  io.log(dim(`     ${payload.thinking.length} thinking block${payload.thinking.length === 1 ? "" : "s"} ` +
-    `(${Math.round(chars / 100) / 10}k characters) of ${state.modelLabel || state.model || "the agent"}'s own`));
-  io.log(dim(`     reasoning, in order${iterations > 0 ? `, plus the ${iterations}-iteration keep/revert list` : ""}. Text only:`));
-  io.log(dim("     no tool calls, no command output, no file contents, no diff."));
+  io.log(dim(`     ${payload.thinking.length} thinking block${payload.thinking.length === 1 ? "" : "s"} (${size}) of ` +
+    `${state.modelLabel || state.model || "the agent"}'s own reasoning, in order` +
+    `${iterations > 0 ? `,` : "."}`));
+  io.log(dim(`     ${iterations > 0 ? `plus the ${iterations}-iteration keep/revert list. ` : ""}` +
+    "Text only: no tool calls, no command"));
+  io.log(dim("     output, no file contents, no diff."));
   io.log(dim("     Kept privately on the makefaster server to post-train a small model on how"));
   io.log(dim("     the loop reasons. Never shown on the boards, never served by any endpoint,"));
   io.log(dim("     and never fed to another run's checklist."));

--- a/packages/cli/lib/session.js
+++ b/packages/cli/lib/session.js
@@ -3,6 +3,7 @@
  * the agent, the kickoff/continue prompts, and the hidden agent spawn.
  */
 
+import { randomUUID } from "node:crypto";
 import { appendFileSync, existsSync, mkdirSync, readFileSync, writeFileSync, copyFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -11,6 +12,7 @@ import { runClaudeSession } from "./agents/claudeCode.js";
 import { runCodexSession } from "./agents/codexAppServer.js";
 import { runOpenRouterSession } from "./agents/openrouter.js";
 import { createProgressReporter } from "./progress.js";
+import { openThinkingTrace, resetThinkingTrace, withThinkingTrace } from "./thinkingTrace.js";
 
 const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
 const SKILL_SOURCE = join(PACKAGE_ROOT, "packages", "skill", "SKILL.md");
@@ -26,6 +28,10 @@ export function sessionPaths(cwd) {
     state: join(dir, "state.json"),
     results: join(dir, "results.json"),
     steps: join(dir, "thinking.log"),
+    // The hidden agent's own reasoning, captured from the protocol stream so
+    // the end screen can offer to submit it. Nothing reads it during the run
+    // and nothing but an explicit yes ever sends it. See thinkingTrace.js.
+    trace: join(dir, "thinking-trace.jsonl"),
     pending: join(dir, "pending-submissions.json"),
   };
 }
@@ -65,8 +71,9 @@ export function prepareSession({ cwd, provider, model, checklist, checklistSourc
   copyFileSync(SKILL_SOURCE, paths.skill);
   writeFileSync(paths.improvements, JSON.stringify({ source: checklistSource, categories: checklist }, null, 2) + "\n");
   // A fresh session starts on an empty panel rather than replaying the last
-  // run's steps.
+  // run's steps, and on an empty trace rather than the last run's reasoning.
   writeFileSync(paths.steps, "");
+  resetThinkingTrace(paths.trace);
 
   const plan = runPlan(checklist, extras);
   const state = {
@@ -74,6 +81,9 @@ export function prepareSession({ cwd, provider, model, checklist, checklistSourc
     provider: provider.key,
     model: model?.id ?? null,
     modelLabel: model?.label ?? null,
+    // A name for this session, so a submitted trace can be told apart from
+    // another run of the same site without carrying anything identifying.
+    runId: randomUUID(),
     startedAt: new Date().toISOString(),
     apiBase,
     siteUrl: siteUrl || null,
@@ -191,10 +201,18 @@ export function continuePrompt(plan) {
  * contain (see runPlan). Only the hosted provider needs it, and only to size
  * its own runaway guard.
  *
+ * Every provider's reasoning is captured to `.makefaster/thinking-trace.jsonl`
+ * on the way past — a local file under a directory the session already keeps
+ * out of git, which the end screen can offer to submit and which nothing else
+ * reads. It is not shown anywhere: the dashboard's panel is the agent's own
+ * `thinking.log`, and that has not changed.
+ *
  * @returns {Promise<{exitCode: number, stderrTail: string, eventCount: number, lastLabel: string|null, aborted: boolean, authRequired: boolean, detail: string|null}>}
  */
 export async function runAgent({ provider, prompt, cwd, model = null, env = process.env, reporter, signal, apiBase, plannedRuns = null }) {
   const progress = reporter ?? createProgressReporter();
+  const trace = openThinkingTrace({ path: sessionPaths(cwd).trace });
+  const tracing = withThinkingTrace(progress, trace);
   const runners = {
     cursor: runAcpSession,
     claude: runClaudeSession,
@@ -207,12 +225,16 @@ export async function runAgent({ provider, prompt, cwd, model = null, env = proc
   const runner = runners[provider.key];
   if (!runner) throw new Error(`no protocol runner is defined for provider "${provider.key}"`);
 
-  const result = await runner({ provider, prompt, cwd, model, env, reporter: progress, signal });
-  return {
-    ...result,
-    eventCount: progress.eventCount,
-    lastLabel: progress.lastLabel,
-    authRequired: Boolean(result.authRequired),
-    detail: result.detail ?? null,
-  };
+  try {
+    const result = await runner({ provider, prompt, cwd, model, env, reporter: tracing, signal });
+    return {
+      ...result,
+      eventCount: progress.eventCount,
+      lastLabel: progress.lastLabel,
+      authRequired: Boolean(result.authRequired),
+      detail: result.detail ?? null,
+    };
+  } finally {
+    trace.close();
+  }
 }

--- a/packages/cli/lib/thinkingTrace.js
+++ b/packages/cli/lib/thinkingTrace.js
@@ -1,0 +1,254 @@
+/**
+ * The hidden agent's reasoning, captured to `.makefaster/thinking-trace.jsonl`.
+ *
+ * This is NOT `.makefaster/thinking.log`. That file is the agent's own
+ * user-facing report — one tagged line per step, written on purpose, and the
+ * only thing the dashboard shows (see stepLog.js). This file is the other
+ * thing: the thinking text the provider's protocol stream carries and that
+ * makefaster otherwise collapses into the word "thinking" and throws away.
+ *
+ * Nothing reads it during a run. It exists so the end screen can offer to
+ * submit the round's chain of thought — a separate, explicit yes — and it is
+ * written under `.makefaster/`, which the session already excludes from git.
+ *
+ * What goes in: reasoning text, in order, and nothing else. Tool calls, tool
+ * results, file contents and command output are not thinking, so no extractor
+ * below reads them and the caps make an accidental log dump impossible anyway.
+ */
+
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+
+/** One block of reasoning; longer than this is a transcript, not a thought. */
+export const MAX_BLOCK_CHARS = 8_000;
+
+/** How many blocks one round may record. */
+export const MAX_BLOCKS = 400;
+
+/** The whole file's ceiling, so a chatty model cannot fill a disk. */
+export const MAX_TOTAL_CHARS = 200_000;
+
+/** Chunks this far apart are separate thoughts rather than one being streamed. */
+const COALESCE_GAP_MS = 4_000;
+
+function textOf(content) {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) return content.map(textOf).filter(Boolean).join("");
+  if (content && typeof content === "object" && typeof content.text === "string") return content.text;
+  return "";
+}
+
+/**
+ * The reasoning text in one parsed stream event, or null when the event is not
+ * a thought. Every branch reads a field the provider documents as reasoning —
+ * never a tool result, a diff, or a command's output.
+ *
+ * @param {string} streamFormat "acp", "claude-stream-json", "codex-app-server",
+ *   "codex-jsonl", or "openai-message" (the hosted provider's own completions)
+ * @param {unknown} event
+ * @returns {string|null}
+ */
+export function thinkingTextOf(streamFormat, event) {
+  if (!event || typeof event !== "object") return null;
+  const text = extract(streamFormat, event);
+  // Returned verbatim, not trimmed: reasoning arrives as deltas and the spaces
+  // between them are part of the sentence. The block is trimmed when it closes.
+  return typeof text === "string" && text.trim() !== "" ? text : null;
+}
+
+function extract(streamFormat, event) {
+  switch (streamFormat) {
+    case "acp":
+      return event.sessionUpdate === "agent_thought_chunk" ? textOf(event.content) : null;
+
+    case "claude-stream-json": {
+      if (event.type !== "assistant") return null;
+      const blocks = event.message?.content;
+      if (!Array.isArray(blocks)) return null;
+      // `redacted_thinking` is deliberately skipped: it is an encrypted blob,
+      // not text, and it is not ours to try to unwrap.
+      return blocks
+        .filter((block) => block && block.type === "thinking")
+        .map((block) => (typeof block.thinking === "string" ? block.thinking : textOf(block)))
+        .filter(Boolean)
+        .join("\n")
+        || null;
+    }
+
+    case "codex-app-server": {
+      const method = String(event.method || "");
+      if (method === "item/reasoning/delta") return textOf(event.params?.delta);
+      if (/^item\/(started|updated|completed)$/.test(method)) {
+        const item = event.params?.item;
+        return item && item.type === "reasoning" ? textOf(item.text ?? item.summary) : null;
+      }
+      return null;
+    }
+
+    case "codex-jsonl": {
+      const inner = event.msg && typeof event.msg === "object" ? event.msg : event;
+      const item = inner.item && typeof inner.item === "object" ? inner.item : null;
+      if (item && /reasoning/.test(String(item.item_type || item.type || ""))) {
+        return textOf(item.text ?? item.summary);
+      }
+      return /^agent_reasoning/.test(String(inner.type || "")) ? textOf(inner.delta ?? inner.text) : null;
+    }
+
+    // The hosted provider holds the conversation itself, so its "event" is an
+    // assistant message. OpenRouter puts reasoning in one of three shapes
+    // depending on the upstream model.
+    case "openai-message": {
+      if (typeof event.reasoning === "string") return event.reasoning;
+      if (typeof event.reasoning_content === "string") return event.reasoning_content;
+      return Array.isArray(event.reasoning_details) ? textOf(event.reasoning_details) : null;
+    }
+
+    default:
+      return null;
+  }
+}
+
+/**
+ * A trace file, open for one round.
+ *
+ * Providers stream reasoning as many small chunks, so chunks that arrive back
+ * to back are one block: `record` appends into an open buffer and `flush`
+ * closes it. The reporter decoration below flushes on the first event that is
+ * not a thought, which is exactly where one block of reasoning ends.
+ *
+ * A chunk that contains everything already buffered is a cumulative snapshot
+ * rather than a continuation (some providers send both the deltas and the
+ * finished text), so it replaces the buffer instead of doubling it.
+ *
+ * @param {object} args
+ * @param {string} args.path
+ * @param {() => number} [args.clock] test seam
+ */
+export function openThinkingTrace({ path, clock = Date.now }) {
+  let buffer = "";
+  let lastAt = 0;
+  let blocks = 0;
+  let chars = 0;
+  let dropped = 0;
+
+  function full() {
+    return blocks >= MAX_BLOCKS || chars >= MAX_TOTAL_CHARS;
+  }
+
+  function flush() {
+    const text = buffer.trim();
+    buffer = "";
+    if (text === "") return;
+    if (full()) {
+      dropped += 1;
+      return;
+    }
+    const entry = { seq: blocks + 1, at: new Date(clock()).toISOString(), text: text.slice(0, MAX_BLOCK_CHARS) };
+    try {
+      appendFileSync(path, JSON.stringify(entry) + "\n");
+    } catch {
+      return; // a trace nobody asked for yet must never break the run
+    }
+    blocks += 1;
+    chars += entry.text.length;
+  }
+
+  return {
+    /** @param {string|null|undefined} text */
+    record(text) {
+      if (typeof text !== "string" || text.trim() === "") return;
+      const now = clock();
+      if (buffer !== "" && now - lastAt > COALESCE_GAP_MS) flush();
+      lastAt = now;
+
+      if (buffer !== "" && text.startsWith(buffer)) buffer = text;
+      else if (buffer !== "" && buffer.endsWith(text)) return;
+      else buffer += text;
+
+      if (buffer.length >= MAX_BLOCK_CHARS) flush();
+    },
+    flush,
+    close() {
+      flush();
+    },
+    get stats() {
+      return { blocks, chars, dropped };
+    },
+  };
+}
+
+/**
+ * Wrap a reporter so the trace fills itself from the same stream the progress
+ * line already consumes. `thought` is what the agent modules call with raw
+ * reasoning text; `update` keeps its existing meaning and doubles as the block
+ * boundary, because an event that is not a thought means the thought ended.
+ *
+ * The wrapper is transparent: `eventCount` and `lastLabel` still come from the
+ * reporter underneath, so the dashboard and the plain progress line behave
+ * exactly as they did.
+ *
+ * @param {{update: Function, done: Function}} reporter
+ * @param {{record: Function, flush: Function}} trace
+ */
+export function withThinkingTrace(reporter, trace) {
+  return {
+    get eventCount() {
+      return reporter.eventCount;
+    },
+    get lastLabel() {
+      return reporter.lastLabel;
+    },
+    update(entry) {
+      const tag = entry && typeof entry === "object" ? entry.tag : null;
+      if (tag !== "HYPOTHESIS") trace.flush();
+      reporter.update(entry);
+    },
+    thought(text) {
+      trace.record(text);
+    },
+    done() {
+      trace.flush();
+      reporter.done?.();
+    },
+  };
+}
+
+/**
+ * Read a trace back as ordered blocks. Unparseable lines are skipped rather
+ * than failing: the file is appended to by a live run, so the last line may be
+ * half-written when a round is stopped.
+ *
+ * @param {string} path
+ * @returns {Array<{at: string, text: string}>}
+ */
+export function readThinkingTrace(path) {
+  if (!existsSync(path)) return [];
+  let contents;
+  try {
+    contents = readFileSync(path, "utf8");
+  } catch {
+    return [];
+  }
+  const blocks = [];
+  for (const line of contents.split(/\r?\n/)) {
+    if (line.trim() === "") continue;
+    let entry;
+    try {
+      entry = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    const text = typeof entry?.text === "string" ? entry.text.trim() : "";
+    if (text === "") continue;
+    blocks.push({ at: typeof entry.at === "string" ? entry.at : "", text });
+  }
+  return blocks;
+}
+
+/** Start a round on an empty trace rather than replaying the last one. */
+export function resetThinkingTrace(path) {
+  try {
+    writeFileSync(path, "");
+  } catch {
+    /* the trace is best-effort; a run must not fail over it */
+  }
+}

--- a/packages/cli/test/apiclient.test.mjs
+++ b/packages/cli/test/apiclient.test.mjs
@@ -4,6 +4,7 @@ import {
   DEFAULT_API_BASE,
   buildImprovementsPayload,
   buildSitePayloads,
+  buildTracePayload,
   resolveApiBase,
 } from "../lib/apiClient.js";
 
@@ -222,4 +223,51 @@ test("buildImprovementsPayload leaves site-specific findings off the shared boar
     }),
     null
   );
+});
+
+const TRACE_STATE = {
+  runId: "run-1",
+  provider: "cursor",
+  model: "claude-fable-5",
+  round: 2,
+  startedAt: "2026-08-25T10:00:00.000Z",
+};
+
+test("buildTracePayload carries the thinking blocks in order plus the iteration list", () => {
+  const payload = buildTracePayload({
+    blocks: [{ text: "  first  " }, { text: "" }, { text: "second" }],
+    results: RESULTS,
+    state: TRACE_STATE,
+    resultsSubmitted: true,
+    siteUrl: "example.com",
+  });
+
+  assert.deepEqual(payload.thinking, [{ text: "first" }, { text: "second" }]);
+  assert.equal(payload.runId, "run-1");
+  assert.equal(payload.agent, "cursor");
+  assert.equal(payload.round, 2);
+  assert.equal(payload.resultsSubmitted, true);
+  assert.equal(payload.results.iterations.length, RESULTS.iterations.length);
+  assert.deepEqual(payload.results.final, RESULTS.final);
+  // A trace is not an anonymous submission — it names the product and the PR on
+  // purpose, so a training set can line it up with the run that produced it.
+  assert.equal(payload.product, "Example");
+});
+
+test("buildTracePayload is capped, so a build log cannot ride in as thinking", () => {
+  const payload = buildTracePayload({
+    blocks: Array.from({ length: 600 }, (_, i) => ({ text: `${i} `.padEnd(9000, "x") })),
+    results: null,
+    state: TRACE_STATE,
+  });
+
+  assert.ok(payload.thinking.length <= 400, `blocks: ${payload.thinking.length}`);
+  assert.ok(payload.thinking.every((block) => block.text.length <= 8000));
+  const total = payload.thinking.reduce((sum, block) => sum + block.text.length, 0);
+  assert.ok(total <= 192_000, `total characters: ${total}`);
+});
+
+test("buildTracePayload sends nothing when there is nothing to send", () => {
+  assert.equal(buildTracePayload({ blocks: [], results: null, state: TRACE_STATE }), null);
+  assert.equal(buildTracePayload({ blocks: [{ text: "   " }], results: { parseError: true }, state: TRACE_STATE }), null);
 });

--- a/packages/cli/test/endscreen.test.mjs
+++ b/packages/cli/test/endscreen.test.mjs
@@ -1,0 +1,202 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runEndScreen } from "../lib/endscreen.js";
+import { sessionPaths } from "../lib/session.js";
+
+const RESULTS = {
+  version: 1,
+  site: { url: "example.com", name: "Example", prUrl: "https://github.com/jjcm/example/pull/4" },
+  northStar: "lcp",
+  baseline: { cold: { lcpMs: 2400, ttiMs: 3900 } },
+  final: { cold: { lcpMs: 1750, ttiMs: 3050 } },
+  iterations: [
+    { n: 1, name: "Inline critical CSS", description: "Inlined above-the-fold styles", deltaMs: -260, deltaPct: -10.8, kept: true, notes: "src/app/shell.tsx line 42" },
+    { n: 2, name: "Preload thumbnails", deltaMs: 150, deltaPct: 6.2, kept: false },
+  ],
+};
+
+const STATE = {
+  apiBase: "https://makefaster.test",
+  provider: "cursor",
+  model: "claude-fable-5",
+  modelLabel: "Fable 5",
+  runId: "run-xyz",
+  startedAt: "2026-08-25T10:00:00.000Z",
+  round: 1,
+  checklistCount: 12,
+  extrasBudget: 5,
+  siteUrl: "example.com",
+};
+
+/**
+ * A session directory with a trace in it, plus the recorder the tests assert
+ * on: every prompt in order, every answer given, and every POST made.
+ */
+function harness({ answers, blocks = ["the hero image is the LCP element", "preloading it beat the noise floor"] }) {
+  const cwd = mkdtempSync(join(tmpdir(), "makefaster-endscreen-"));
+  const paths = sessionPaths(cwd);
+  mkdirSync(paths.dir, { recursive: true });
+  writeFileSync(paths.trace, blocks.map((text, i) => JSON.stringify({ seq: i + 1, at: "2026-08-25T10:0" + i + ":00.000Z", text })).join("\n") + (blocks.length > 0 ? "\n" : ""));
+
+  const asked = [];
+  const posts = [];
+  const io = {
+    log() {},
+    question: async () => "",
+    confirm: async (prompt, options) => {
+      asked.push({ prompt: prompt.trim(), def: options?.def });
+      const key = Object.keys(answers).find((needle) => prompt.includes(needle));
+      return key === undefined ? false : answers[key];
+    },
+  };
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    const path = String(url).replace(STATE.apiBase, "");
+    posts.push({ path, payload: JSON.parse(init.body) });
+    const bodies = {
+      "/api/submit-site": { ok: true, created: true, row: {} },
+      "/api/submit-improvements": { ok: true, results: [] },
+      "/api/submit-trace": { ok: true, runId: "run-xyz", thinkingBlocks: blocks.length },
+    };
+    return { ok: true, status: 200, json: async () => bodies[path] ?? { ok: true } };
+  };
+
+  return {
+    paths,
+    asked,
+    posts,
+    io,
+    restore() {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
+async function run(setup) {
+  try {
+    return await runEndScreen({ results: RESULTS, state: STATE, paths: setup.paths, io: setup.io, interactive: true });
+  } finally {
+    setup.restore();
+  }
+}
+
+test("the chain-of-thought question comes after the results questions, not bundled with them", async () => {
+  const setup = harness({ answers: { "Keep looping": false, "Submit site stats": true, "Submit anonymous improvements": true, "Submit the chain of thought": true } });
+  const outcome = await run(setup);
+
+  assert.deepEqual(setup.asked.map((entry) => entry.prompt), [
+    "Keep looping?",
+    "Submit site stats?",
+    "Submit anonymous improvements?",
+    "Submit the chain of thought?",
+  ]);
+  assert.deepEqual(setup.posts.map((post) => post.path), [
+    "/api/submit-site",
+    "/api/submit-improvements",
+    "/api/submit-trace",
+  ]);
+  assert.deepEqual(outcome, { loopMore: false, resultsSubmitted: true, traceSubmitted: true });
+});
+
+test("the chain-of-thought question defaults to no and takes an explicit yes", async () => {
+  const setup = harness({ answers: { "Keep looping": false, "Submit site stats": true, "Submit anonymous improvements": true } });
+  const outcome = await run(setup);
+
+  const cot = setup.asked.find((entry) => entry.prompt.startsWith("Submit the chain"));
+  assert.equal(cot.def, false, "the chain-of-thought prompt must default to no");
+  assert.equal(outcome.traceSubmitted, false);
+  assert.equal(setup.posts.some((post) => post.path === "/api/submit-trace"), false,
+    "declining must send nothing at all");
+});
+
+test("uploading results and declining the chain of thought are independent answers", async () => {
+  // Results yes, trace no.
+  const resultsOnly = harness({ answers: { "Submit site stats": true, "Submit anonymous improvements": true } });
+  const first = await run(resultsOnly);
+  assert.equal(first.resultsSubmitted, true);
+  assert.equal(first.traceSubmitted, false);
+  assert.deepEqual(resultsOnly.posts.map((post) => post.path), ["/api/submit-site", "/api/submit-improvements"]);
+
+  // Results no, trace yes — still asked, and still sent.
+  const traceOnly = harness({ answers: { "Submit the chain of thought": true } });
+  const second = await run(traceOnly);
+  assert.equal(second.resultsSubmitted, false);
+  assert.equal(second.traceSubmitted, true);
+  assert.deepEqual(traceOnly.posts.map((post) => post.path), ["/api/submit-trace"]);
+  assert.equal(traceOnly.posts[0].payload.resultsSubmitted, false,
+    "the trace records that the results were declined");
+});
+
+test("looping more skips every submission question, including the trace", async () => {
+  const setup = harness({ answers: { "Keep looping": true, "Submit the chain of thought": true } });
+  const outcome = await run(setup);
+
+  assert.deepEqual(setup.asked.map((entry) => entry.prompt), ["Keep looping?"]);
+  assert.deepEqual(setup.posts, []);
+  assert.deepEqual(outcome, { loopMore: true, resultsSubmitted: false, traceSubmitted: false });
+});
+
+test("the submitted trace is thinking text plus the iteration list, and nothing else", async () => {
+  const setup = harness({ answers: { "Submit the chain of thought": true } });
+  await run(setup);
+
+  const { payload } = setup.posts.find((post) => post.path === "/api/submit-trace");
+  assert.deepEqual(payload.thinking, [
+    { text: "the hero image is the LCP element" },
+    { text: "preloading it beat the noise floor" },
+  ]);
+  assert.equal(payload.runId, "run-xyz");
+  assert.equal(payload.product, "Example");
+  assert.equal(payload.prUrl, "https://github.com/jjcm/example/pull/4");
+  assert.equal(payload.agent, "cursor");
+  assert.equal(payload.model, "claude-fable-5");
+  assert.equal(payload.round, 1);
+  assert.equal(payload.startedAt, "2026-08-25T10:00:00.000Z");
+  assert.ok(payload.submittedAt);
+
+  assert.deepEqual(payload.results.iterations, [
+    { name: "Inline critical CSS", description: "Inlined above-the-fold styles", kept: true, deltaMs: -260, deltaPct: -10.8 },
+    { name: "Preload thumbnails", kept: false, deltaMs: 150, deltaPct: 6.2 },
+  ]);
+  assert.equal(payload.results.northStar, "lcp");
+  assert.deepEqual(payload.results.baseline, RESULTS.baseline);
+
+  // An iteration's `notes` is where the skill puts everything specific to the
+  // repo, so it must not travel with the trace — and neither may anything that
+  // looks like a tool transcript.
+  const serialized = JSON.stringify(payload);
+  for (const forbidden of ["notes", "shell.tsx", "tool", "stdout", "messages"]) {
+    assert.equal(serialized.includes(forbidden), false, `the trace payload carries ${forbidden}`);
+  }
+});
+
+test("a session that captured no reasoning is not asked and posts nothing", async () => {
+  const setup = harness({ answers: { "Submit the chain of thought": true }, blocks: [] });
+  const outcome = await run(setup);
+
+  assert.equal(setup.asked.some((entry) => entry.prompt.startsWith("Submit the chain")), false);
+  assert.equal(outcome.traceSubmitted, false);
+  assert.deepEqual(setup.posts, []);
+});
+
+test("a non-interactive run answers nothing and submits nothing", async () => {
+  const setup = harness({ answers: { "Submit the chain of thought": true } });
+  try {
+    const outcome = await runEndScreen({
+      results: RESULTS,
+      state: STATE,
+      paths: setup.paths,
+      io: setup.io,
+      interactive: false,
+    });
+    assert.deepEqual(outcome, { loopMore: false, resultsSubmitted: false, traceSubmitted: false });
+    assert.deepEqual(setup.asked, []);
+    assert.deepEqual(setup.posts, []);
+  } finally {
+    setup.restore();
+  }
+});

--- a/packages/cli/test/thinkingtrace.test.mjs
+++ b/packages/cli/test/thinkingtrace.test.mjs
@@ -1,0 +1,165 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  MAX_BLOCKS,
+  MAX_BLOCK_CHARS,
+  openThinkingTrace,
+  readThinkingTrace,
+  resetThinkingTrace,
+  thinkingTextOf,
+  withThinkingTrace,
+} from "../lib/thinkingTrace.js";
+
+function tracePath() {
+  return join(mkdtempSync(join(tmpdir(), "makefaster-trace-")), "thinking-trace.jsonl");
+}
+
+/** A reporter of the shape the agent modules are given. */
+function fakeReporter() {
+  const entries = [];
+  return {
+    entries,
+    eventCount: 0,
+    lastLabel: null,
+    update(entry) {
+      entries.push(entry);
+    },
+    done() {
+      entries.push("done");
+    },
+  };
+}
+
+test("thinkingTextOf reads reasoning out of every provider's stream", () => {
+  assert.equal(
+    thinkingTextOf("acp", { sessionUpdate: "agent_thought_chunk", content: { type: "text", text: "the LCP element is the hero" } }),
+    "the LCP element is the hero",
+  );
+  assert.equal(
+    thinkingTextOf("claude-stream-json", {
+      type: "assistant",
+      message: { content: [{ type: "thinking", thinking: "font swap is not the problem" }] },
+    }),
+    "font swap is not the problem",
+  );
+  assert.equal(
+    thinkingTextOf("codex-app-server", { method: "item/reasoning/delta", params: { delta: "preload " } }),
+    "preload ",
+  );
+  assert.equal(
+    thinkingTextOf("codex-app-server", { method: "item/completed", params: { item: { type: "reasoning", text: "preload the hero" } } }),
+    "preload the hero",
+  );
+  assert.equal(
+    thinkingTextOf("codex-jsonl", { msg: { type: "agent_reasoning", text: "measure before keeping" } }),
+    "measure before keeping",
+  );
+  assert.equal(
+    thinkingTextOf("openai-message", { role: "assistant", reasoning: "walk the checklist in order" }),
+    "walk the checklist in order",
+  );
+  assert.equal(
+    thinkingTextOf("openai-message", { role: "assistant", reasoning_details: [{ text: "one" }, { text: " two" }] }),
+    "one two",
+  );
+});
+
+test("thinkingTextOf never reads a tool call, a tool result, or plain assistant prose", () => {
+  const notThoughts = [
+    ["acp", { sessionUpdate: "tool_call", kind: "execute", rawInput: { command: "yarn build" } }],
+    ["acp", { sessionUpdate: "agent_message_chunk", content: { type: "text", text: "I ran the build" } }],
+    ["claude-stream-json", { type: "assistant", message: { content: [{ type: "tool_use", name: "Bash", input: { command: "yarn build" } }] } }],
+    ["claude-stream-json", { type: "assistant", message: { content: [{ type: "text", text: "here is the plan" }] } }],
+    // Encrypted reasoning is not ours to unwrap, so it is left alone.
+    ["claude-stream-json", { type: "assistant", message: { content: [{ type: "redacted_thinking", data: "AAAA" }] } }],
+    ["claude-stream-json", { type: "user", message: { content: [{ type: "tool_result", content: "1200 lines of output" }] } }],
+    ["codex-app-server", { method: "item/completed", params: { item: { type: "commandExecution", command: "yarn build" } } }],
+    ["codex-jsonl", { msg: { type: "exec_command_begin", command: ["yarn", "build"] } }],
+    ["openai-message", { role: "assistant", content: "the build passed" }],
+  ];
+  for (const [format, event] of notThoughts) {
+    assert.equal(thinkingTextOf(format, event), null, `${format}: ${JSON.stringify(event)}`);
+  }
+});
+
+test("streamed chunks coalesce into one block, and a non-thought event closes it", () => {
+  const path = tracePath();
+  const trace = openThinkingTrace({ path, clock: () => 1_700_000_000_000 });
+  const reporter = withThinkingTrace(fakeReporter(), trace);
+
+  reporter.thought("the hero image ");
+  reporter.update({ tag: "HYPOTHESIS", text: "thinking" });
+  reporter.thought("is the LCP element");
+  reporter.update({ tag: "HYPOTHESIS", text: "thinking" });
+  // A tool call is not a thought, so the block it interrupts is closed.
+  reporter.update({ tag: "EXECUTE", text: "running yarn build" });
+  reporter.thought("that beat the noise floor");
+  reporter.done();
+
+  assert.deepEqual(readThinkingTrace(path).map((block) => block.text), [
+    "the hero image is the LCP element",
+    "that beat the noise floor",
+  ]);
+});
+
+test("a cumulative snapshot replaces the deltas it repeats instead of doubling them", () => {
+  const path = tracePath();
+  const trace = openThinkingTrace({ path, clock: () => 1 });
+  trace.record("preload ");
+  trace.record("preload the hero");
+  trace.record("preload the hero"); // the same text again, as a completed item
+  trace.close();
+
+  assert.deepEqual(readThinkingTrace(path).map((block) => block.text), ["preload the hero"]);
+});
+
+test("the trace is capped, so a chatty model cannot fill a disk", () => {
+  const path = tracePath();
+  const trace = openThinkingTrace({ path, clock: () => 1 });
+
+  trace.record("x".repeat(MAX_BLOCK_CHARS + 500));
+  trace.flush();
+  for (let i = 0; i < MAX_BLOCKS + 20; i++) {
+    trace.record(`thought ${i}`);
+    trace.flush();
+  }
+  trace.close();
+
+  const blocks = readThinkingTrace(path);
+  assert.equal(blocks.length, MAX_BLOCKS);
+  assert.ok(blocks[0].text.length <= MAX_BLOCK_CHARS);
+  assert.ok(trace.stats.dropped > 0);
+});
+
+test("the wrapper is transparent: the reporter underneath still sees every event", () => {
+  const path = tracePath();
+  const trace = openThinkingTrace({ path, clock: () => 1 });
+  const underlying = fakeReporter();
+  const reporter = withThinkingTrace(underlying, trace);
+
+  reporter.update({ tag: "OBSERVE", text: "reading index.html" });
+  reporter.thought("a thought nobody shows");
+  reporter.update(null);
+  reporter.done();
+
+  assert.deepEqual(underlying.entries, [{ tag: "OBSERVE", text: "reading index.html" }, null, "done"]);
+  // And the thought went to the file rather than to the reporter.
+  assert.deepEqual(readThinkingTrace(path).map((block) => block.text), ["a thought nobody shows"]);
+});
+
+test("a half-written line is skipped rather than failing the read", () => {
+  const path = tracePath();
+  writeFileSync(path, `{"seq":1,"at":"2026-08-25T00:00:00.000Z","text":"complete"}\n{"seq":2,"at":"2026`);
+  assert.deepEqual(readThinkingTrace(path).map((block) => block.text), ["complete"]);
+
+  resetThinkingTrace(path);
+  assert.equal(readFileSync(path, "utf8"), "");
+  assert.deepEqual(readThinkingTrace(path), []);
+});
+
+test("reading a trace that was never written is empty, not an error", () => {
+  assert.deepEqual(readThinkingTrace(join(tracePath(), "nope", "missing.jsonl")), []);
+});

--- a/packages/skill/SKILL.md
+++ b/packages/skill/SKILL.md
@@ -36,6 +36,7 @@ The CLI owns this directory. Never commit it (it is already in
 | `state.json` | CLI (read-only for you) | the run's plan: `checklistCount`, `extrasBudget`, `plannedRuns`, the round |
 | `results.json` | **you**, after every iteration | the session record the CLI reads back |
 | `thinking.log` | **you**, as each step starts | one tagged line per step — the only thing the user sees while you work |
+| `thinking-trace.jsonl` | CLI (not yours — do not read or write it) | your provider's own reasoning text, captured off the protocol stream in case the user chooses to submit it after the run |
 
 `improvements.json` is **the order you work in and the length of the run** (see
 Step 2), not a script to apply blindly: you still judge whether each category is


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Collects the one thing the loop produces that neither leaderboard can hold — **how the agent reasoned** — as a separate, explicitly-opted-in submission, stored where nothing serves it.

Nothing here touches the public boards. `GET /data/*.json` is byte-for-byte unchanged by a trace submit (there is a test that captures both documents before and compares after), traces are not on either board, and they are not where the CLI's imported checklist comes from — that is `GET /data/improvements.json` and only that.

## The TUI: two sequential decisions

The end screen asked three questions and now asks four. Questions 2 and 3 are still the **results** of the run; question 4 is the **chain of thought**, asked only once the results question has an answer, and never inferred from it.

```text
  2. Submit stats to the Site leaderboard?
     Your site's URL and favicon will be displayed publicly, with its
     measured LCP/TTI and the improvement since baseline.
     The row's name will link to https://github.com/jjcm/dify/pull/12.
     It will also show that 100% of what you kept was reusable technique.
     Submit site stats? [y/N]

  3. Submit anonymous improvements data?
     No URL, no site identity — only what worked (1 improvement: name, description, deltas). This
     grows the public improvement leaderboard every site learns from.
     Submit anonymous improvements? [y/N]

  4. Submit this session's chain of thought? (separate question, off by default)
     3 thinking blocks (12.4k characters) of Fable 5's own reasoning, in order,
     plus the 2-iteration keep/revert list. Text only: no tool calls, no command
     output, no file contents, no diff.
     Kept privately on the makefaster server to post-train a small model on how
     the loop reasons. Never shown on the boards, never served by any endpoint,
     and never fed to another run's checklist.
     .makefaster/thinking-trace.jsonl is the exact file — read it first if you like.
     Submit the chain of thought? [y/N]
```

All four combinations are real answers: results and trace, results only, trace only, neither. The payload records which happened (`resultsSubmitted`), because a training set should know whether the run it is reading also went on a board. The prompt **defaults to no and takes an explicit yes** — a default of yes would be an upload the user never made — and a non-interactive run is never offered it at all.

## Capturing the reasoning

The CLI did not have the chain of thought to submit: all four providers stream reasoning and makefaster collapsed every bit of it into the word `thinking` on the way to the progress line. That is right for the dashboard and wrong for this, so `packages/cli/lib/thinkingTrace.js` reads the field each provider documents as reasoning — an ACP `agent_thought_chunk`, a Claude `thinking` block, a Codex `reasoning` item or delta, an OpenRouter `reasoning` field — and appends it to `.makefaster/thinking-trace.jsonl`.

Streamed chunks coalesce into blocks and the first event that is not a thought closes one, so a trace reads as blocks rather than as tokens. A cumulative snapshot replaces the deltas it repeats instead of doubling them. Nothing reads the file during a run, it is under the directory the session already keeps out of git, and it can be read before answering.

`.makefaster/thinking.log` is **not** this file and has not changed: it stays the agent's own tagged one-liners and the only thing the dashboard shows.

## Where a trace goes

`POST /api/submit-trace` writes one JSON document per run under `MAKEFASTER_TRACE_DIR` (`/var/lib/makefaster/traces` by default) as `<yyyy-mm>/<run id>.json` — a `0600` file in a `0700` directory, outside the repo and outside `FRONTEND_DIR`, because the one thing that must never happen to a trace is being served as a static asset. The new `traces` table is the index beside it: counts and metadata, not content. A resubmission of the same run replaces its own document rather than adding a second copy.

There is no `GET` counterpart, and unknown `GET` paths under `/api/` now answer `404` rather than the SPA shell, so a route nobody wrote cannot become one the static fallback answers. A deployment with `MAKEFASTER_TRACE_DIR=off` (or unset) collects nothing and says so with a `503` naming the setting.

## What cannot get in

Everything stored is **whitelisted rather than filtered**. `thinking` is read for text; `results` is re-read field by field into `internal/trace.Results`, so an iteration's `notes` — where the skill puts everything specific to one repo — stays on the submitter's disk.

A payload carrying a tool transcript, a build log, or a `tool_result` block (`messages`, `toolResults`, `stdout`, a block whose `type` names a tool…) is **refused with the reason** rather than quietly stripped: a trace that silently is not what it claims would be worse than no trace. And the caps mean a `yarn build` log cannot arrive dressed as reasoning either — 400 blocks, 8k characters each, 200k in total, 200 iterations, a 96 KB diff, behind a 512 KB body wall. Whatever had to be clamped comes back in the response, so the acknowledgement is honest about being partial.

The CLI sends no diff. The loop's changes are in the pull request the site row already links to, and shipping a user's source under a question about reasoning would be answering something they were not asked. Diffs come from backfills, where Speed Lab already has the patch.

## Backfilling already-packed runs

Speed Lab has runs on disk, and those do not need the TUI to get onto the box:

```bash
cd backend && go build -o /usr/local/bin/makefaster-traces ./cmd/traces

makefaster-traces import --dir /srv/backfill/2026-08     # a directory of runs
makefaster-traces import --tar /srv/backfill/runs.tar.gz # or a tar/tar.gz
makefaster-traces import --dir ./runs --dry-run          # validate, write nothing
makefaster-traces list --limit 20                        # the private index
```

One directory per run:

```text
<run>/
  meta.json        required — { runId?, product?, prUrl?, agent?, model?,
                               round?, startedAt?, submittedAt?,
                               resultsSubmitted? }
  thinking.jsonl   required — one {"text": "…"} per line, in order
                              (a bare JSON string per line also reads)
  results.json     optional — the run's results.json
  diff.patch       optional — the unified patch, truncated to the size cap
```

A `--tar` is a tar of the same tree; the first path segment of each entry is the run, so `tar -cf runs.tar run-*/` and a tar with a wrapping directory import alike. A run with no `runId` is named after its directory, so re-importing the same export is one trace rather than two, and a run already stored is skipped unless `--replace` — an interrupted backfill is safe to re-run.

Imports produce the same `internal/trace.Trace` the endpoint produces, so an imported trace and a submitted one are indistinguishable once stored: same whitelisting, same caps, same refusal to take tool output in place of thinking. `list` reads the index on the box; it is deliberately not an HTTP endpoint and deliberately not something the CLI can reach.

## Tests

`npm test` — 185 pass (18 new). `cd backend && go test ./...` green, with the MariaDB-backed suite run against a real database rather than skipped.

The end screen's questions are a test rather than a promise: that the chain of thought is asked **after** the results question and not bundled with it, that its prompt defaults to no, that declining posts nothing at all, that declining the results and accepting it still submits, and that the payload is thinking text plus the iteration list with no `notes` and nothing resembling a tool transcript. The capture is tested per provider stream — a reasoning chunk is captured, a tool call and plain assistant prose are not — plus coalescing and the caps.

On the server: **both public documents captured byte for byte before a trace submit and compared after**, then searched by hand for the reasoning; what has no route (`GET /api/submit-trace`, `/api/traces`, the document path — all `404`, none of them the SPA shell); five shapes of tool transcript, each `400` with nothing written; the caps and the `413`; a resubmission replacing rather than duplicating; `0600` documents in a `0700` directory; a client-supplied run id that cannot escape it (`../../etc/passwd`); and the backfill importer over both a directory and a tar, refusing tool output there too.

Verified end to end against a running server and a real MariaDB, too: the CLI's own capture → payload → `POST /api/submit-trace` → document on disk, with the boards byte-identical across it, every `GET` a 404, and the packed-run importer run for real (fresh, re-run-skips, tar, `list`).

## No secrets

No credentials added or read. `MAKEFASTER_TRACE_DIR` is a path, documented in `env.example`, and the trace directory is intentionally outside anything that publishes or gets backed up by something that does.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d45bfbe3-8efb-4b2a-96ce-6a6a993a6351?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d45bfbe3-8efb-4b2a-96ce-6a6a993a6351&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

