### PR TITLE
Fix picker TUI bugs (arrows, overflow ghosting, name-only rows) and isolate Lighthouse from the user's Chrome

### DIFF
--- a/packages/cli/bin/makefaster.js
+++ b/packages/cli/bin/makefaster.js
@@ -19,7 +19,7 @@ import { listModels } from "../lib/agents/modelList.js";
 import { importChecklist } from "../lib/improvements.js";
 import { signedOutGuidance } from "../lib/invoke.js";
 import { createLoopView } from "../lib/loopView.js";
-import { modelsForProvider, resolveHostedModel, resolveModel } from "../lib/models.js";
+import { modelPickerOptions, modelsForProvider, resolveHostedModel, resolveModel } from "../lib/models.js";
 import { confirm, selectFrom } from "../lib/picker.js";
 import { createTui, tuiSupported } from "../lib/tui.js";
 import {
@@ -156,7 +156,7 @@ async function pickHostedModel(provider, modelFlag) {
   try {
     const index = await selectFrom({
       title: dim("  the server allowlists these; nothing else can be requested"),
-      options: models.map((model) => ({ label: `${model.label}  ${dim(model.id)}`, detail: model.detail })),
+      options: modelPickerOptions(models),
       defaultIndex: 0,
     });
     if (index === null) process.exit(0);
@@ -201,7 +201,6 @@ async function pickModel(provider, modelFlag, cwd) {
   const ranked = models.filter((model) => model.score !== null).length;
   const source = live.models ? `from ${provider.displayName}'s own model list` : "from makefaster's catalog";
   console.log(`  ${bold(`Which model should ${provider.displayName} run?`)} ${dim(`(${ranked} of ${models.length} ranked by CursorBench 3.2, ${source})`)}`);
-  console.log(dim("  the score ranks the model family; the id is what this CLI accepts"));
   if (ranked < models.length) {
     console.log(dim(`  ${provider.displayName} has ${ranked} model${ranked === 1 ? "" : "s"} in the snapshot; the rest are its own next-best models, unranked.`));
   }
@@ -209,7 +208,7 @@ async function pickModel(provider, modelFlag, cwd) {
   try {
     const index = await selectFrom({
       title: dim("  most intelligent first"),
-      options: models.map((model) => ({ label: `${model.label}  ${dim(model.id)}`, detail: model.detail })),
+      options: modelPickerOptions(models),
       defaultIndex: 0,
     });
     if (index === null) process.exit(0);

--- a/packages/cli/lib/models.js
+++ b/packages/cli/lib/models.js
@@ -213,6 +213,18 @@ export function modelsForProvider(providerKey, { live = null } = {}) {
     .map(({ order, ...model }) => model);
 }
 
+/**
+ * The picker's rows: the model name and nothing else. The id slug, the
+ * CursorBench score, and the "best for" copy stay out of the list — the row a
+ * user scans is the name, and the id is confirmed right after the choice.
+ *
+ * @param {Array<{label: string}>} models
+ * @returns {Array<{label: string}>}
+ */
+export function modelPickerOptions(models) {
+  return models.map((model) => ({ label: model.label }));
+}
+
 /** The top-intelligence model for a provider — the picker's default highlight. */
 export function defaultModelFor(providerKey, options) {
   return modelsForProvider(providerKey, options)[0] ?? null;

--- a/packages/cli/lib/picker.js
+++ b/packages/cli/lib/picker.js
@@ -9,10 +9,128 @@
 import readline from "node:readline";
 import { bold, cyan, dim } from "./ui.js";
 
-function requireTty() {
-  if (!process.stdin.isTTY) {
+/**
+ * How long a lone ESC byte may sit unfollowed before it means "the user pressed
+ * Escape" rather than "an arrow sequence is still arriving". Arrow keys are
+ * multi-byte escape sequences, and raw-mode reads are allowed to split them
+ * across `data` events — which happens in practice when the terminal is busy,
+ * e.g. repainting a small window every keypress.
+ */
+const ESC_GRACE_MS = 50;
+
+function requireTty(stdin = process.stdin) {
+  if (!stdin.isTTY) {
     throw Object.assign(new Error("interactive prompt needs a TTY"), { code: "NO_TTY" });
   }
+}
+
+const SGR_PATTERN = /\u001b\[[0-9;]*m/g;
+
+/** Visible width of a line, not counting ANSI style sequences. */
+export function visibleLength(text) {
+  return String(text).replace(SGR_PATTERN, "").length;
+}
+
+/**
+ * Clip a (possibly styled) line to `width` visible columns, ellipsizing when it
+ * would overflow. Style sequences are carried through without counting, and a
+ * clipped styled line ends with a reset so the cut cannot leak color into the
+ * next row. Picker rows must never wrap: a wrapped row occupies more physical
+ * lines than the renderer accounts for, and the stale extra lines are what
+ * ghosting is made of.
+ */
+export function clipLine(text, width) {
+  const line = String(text);
+  if (visibleLength(line) <= width) return line;
+  let out = "";
+  let visible = 0;
+  let styled = false;
+  let i = 0;
+  const budget = Math.max(0, width - 1); // reserve one column for the ellipsis
+  while (i < line.length && visible < budget) {
+    if (line[i] === "\u001b") {
+      const match = /^\u001b\[[0-9;]*m/.exec(line.slice(i));
+      if (match) {
+        out += match[0];
+        styled = true;
+        i += match[0].length;
+        continue;
+      }
+    }
+    out += line[i];
+    visible += 1;
+    i += 1;
+  }
+  return `${out}…${styled ? "\u001b[0m" : ""}`;
+}
+
+const SEQUENCE_NAMES = { A: "up", B: "down", C: "right", D: "left", H: "home", F: "end" };
+
+/**
+ * Decode raw-mode bytes into key events, tolerating escape sequences that are
+ * split across reads. Returns the keys that are complete plus the trailing
+ * bytes that may still be the start of one, for the caller to prepend to the
+ * next chunk. Both CSI ("\u001b[A") and SS3 ("\u001bOA") arrows decode to the
+ * same names, because terminals in application-cursor-keys mode send the
+ * latter and a picker has no say in which mode it inherits.
+ *
+ * @param {string} input
+ * @returns {{keys: Array<{name: string, sequence: string}>, pending: string}}
+ */
+export function parseKeys(input) {
+  const keys = [];
+  let i = 0;
+  while (i < input.length) {
+    const ch = input[i];
+    if (ch !== "\u001b") {
+      keys.push({ name: ch, sequence: ch });
+      i += 1;
+      continue;
+    }
+    if (i === input.length - 1) {
+      // ESC with nothing after it yet: maybe Escape, maybe half an arrow.
+      return { keys, pending: "\u001b" };
+    }
+    const introducer = input[i + 1];
+    if (introducer === "[" || introducer === "O") {
+      let j = i + 2;
+      while (j < input.length && /[0-9;]/.test(input[j])) j += 1;
+      if (j === input.length) return { keys, pending: input.slice(i) };
+      const final = input[j];
+      keys.push({ name: SEQUENCE_NAMES[final] ?? `sequence-${final}`, sequence: input.slice(i, j + 1) });
+      i = j + 1;
+      continue;
+    }
+    // ESC followed by an ordinary byte is a real Escape press, then that byte.
+    keys.push({ name: "escape", sequence: "\u001b" });
+    i += 1;
+  }
+  return { keys, pending: "" };
+}
+
+/**
+ * The picker frame as fully-clipped lines — pure, so tests can render at any
+ * size. Every line fits `width` (no wrapping, ever), and when the options
+ * outnumber the rows available only a window around the selection is shown, so
+ * the frame also fits `height` and cursor-up repositioning cannot clamp
+ * against the top of a short terminal.
+ */
+export function renderFrame({ title, options, index, width, height }) {
+  const chrome = 2; // the title and the footer
+  const visibleCount = Math.max(1, Math.min(options.length, height - chrome));
+  const first = Math.min(
+    Math.max(0, index - Math.floor((visibleCount - 1) / 2)),
+    options.length - visibleCount,
+  );
+  const rows = options.slice(first, first + visibleCount).map((option, offset) => {
+    const i = first + offset;
+    const pointer = i === index ? cyan(">") : " ";
+    const label = i === index ? bold(option.label) : option.label;
+    const detail = option.detail ? `  ${dim(option.detail)}` : "";
+    return `  ${pointer} ${i + 1}. ${label}${detail}`;
+  });
+  const lines = [title, ...rows, dim("  arrows/jk move - enter select - q cancel")];
+  return lines.map((line) => clipLine(line, width));
 }
 
 /**
@@ -20,48 +138,81 @@ function requireTty() {
  * @param {string} args.title
  * @param {Array<{label: string, detail?: string}>} args.options
  * @param {number} [args.defaultIndex]
+ * @param {NodeJS.ReadStream} [args.stdin]
+ * @param {NodeJS.WriteStream} [args.stdout]
  * @returns {Promise<number|null>} selected index, or null when cancelled
  */
-export function selectFrom({ title, options, defaultIndex = 0 }) {
-  requireTty();
+export function selectFrom({ title, options, defaultIndex = 0, stdin = process.stdin, stdout = process.stdout }) {
+  requireTty(stdin);
   return new Promise((resolve) => {
-    const stdin = process.stdin;
-    const stdout = process.stdout;
     let index = Math.min(Math.max(defaultIndex, 0), options.length - 1);
     let renderedLines = 0;
+    let pending = "";
+    let escTimer = null;
+    let done = false;
 
     function render() {
-      if (renderedLines > 0) {
-        stdout.write(`\u001b[${renderedLines}A\u001b[J`);
-      }
-      const lines = [title, ...options.map((option, i) => {
-        const pointer = i === index ? cyan(">") : " ";
-        const label = i === index ? bold(option.label) : option.label;
-        const detail = option.detail ? `  ${dim(option.detail)}` : "";
-        return `  ${pointer} ${i + 1}. ${label}${detail}`;
-      }), dim("  arrows/jk move - enter select - q cancel")];
+      // Up over exactly the lines the previous frame drew, back to column 1,
+      // and clear to the end of the screen. This is only sound because every
+      // frame line is clipped to the terminal width: renderFrame guarantees a
+      // logical line is one physical line, so the count cannot drift.
+      if (renderedLines > 0) stdout.write(`\u001b[${renderedLines}A\u001b[G\u001b[J`);
+      const lines = renderFrame({
+        title,
+        options,
+        index,
+        width: stdout.columns || 80,
+        height: stdout.rows || 24,
+      });
       stdout.write(lines.join("\n") + "\n");
       renderedLines = lines.length;
     }
 
     function finish(result) {
+      if (done) return;
+      done = true;
+      if (escTimer !== null) {
+        clearTimeout(escTimer);
+        escTimer = null;
+      }
       stdin.setRawMode(false);
       stdin.pause();
       stdin.removeListener("data", onData);
       resolve(result);
     }
 
-    function onData(chunk) {
-      const key = chunk.toString("utf8");
-      if (key === "\u0003" || key === "q" || key === "\u001b") return finish(null); // ctrl-c / q / esc
-      if (key === "\r" || key === "\n") return finish(index);
-      if (key === "\u001b[A" || key === "k") index = (index - 1 + options.length) % options.length;
-      else if (key === "\u001b[B" || key === "j") index = (index + 1) % options.length;
-      else if (/^[1-9]$/.test(key)) {
-        const n = Number.parseInt(key, 10) - 1;
+    function handleKey(key) {
+      if (key.name === "\u0003" || key.name === "q" || key.name === "escape") return finish(null); // ctrl-c / q / esc
+      if (key.name === "\r" || key.name === "\n") return finish(index);
+      if (key.name === "up" || key.name === "k") index = (index - 1 + options.length) % options.length;
+      else if (key.name === "down" || key.name === "j") index = (index + 1) % options.length;
+      else if (/^[1-9]$/.test(key.name)) {
+        const n = Number.parseInt(key.name, 10) - 1;
         if (n < options.length) { index = n; render(); return finish(index); }
-      }
+        return;
+      } else return;
       render();
+    }
+
+    function onData(chunk) {
+      if (escTimer !== null) {
+        clearTimeout(escTimer);
+        escTimer = null;
+      }
+      const parsed = parseKeys(pending + chunk.toString("utf8"));
+      pending = parsed.pending;
+      for (const key of parsed.keys) {
+        handleKey(key);
+        if (done) return;
+      }
+      if (pending === "\u001b") {
+        escTimer = setTimeout(() => {
+          escTimer = null;
+          pending = "";
+          handleKey({ name: "escape", sequence: "\u001b" });
+        }, ESC_GRACE_MS);
+        escTimer.unref?.();
+      }
     }
 
     stdin.setRawMode(true);

--- a/packages/cli/test/picker.test.mjs
+++ b/packages/cli/test/picker.test.mjs
@@ -1,0 +1,250 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { clipLine, parseKeys, renderFrame, selectFrom, visibleLength } from "../lib/picker.js";
+import { HOSTED_MODELS, modelPickerOptions, modelsForProvider } from "../lib/models.js";
+
+const stripStyles = (text) => text.replace(/\u001b\[[0-9;]*m/g, "");
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * A minimal terminal emulator — glyph grid, deferred autowrap, and the control
+ * sequences the picker uses (cursor up, column 1, clear below; styles are
+ * dropped). It exists so a test can see exactly what a real terminal would
+ * show, including the wrapped ghost lines the old renderer left behind.
+ */
+function createScreen({ columns }) {
+  const cells = [[]];
+  let row = 0;
+  let col = 0;
+  let wraps = 0;
+  const ensure = (r) => { while (cells.length <= r) cells.push([]); };
+  return {
+    get wraps() { return wraps; },
+    write(text) {
+      const tokens = String(text).match(/\u001b\[[0-9;]*[A-Za-z~]|[\s\S]/g) ?? [];
+      for (const token of tokens) {
+        if (token[0] === "\u001b") {
+          const match = /^\u001b\[([0-9;]*)([A-Za-z~])$/.exec(token);
+          if (!match) continue;
+          const [, params, final] = match;
+          if (final === "A") row = Math.max(0, row - Number(params || "1"));
+          else if (final === "G") col = 0;
+          else if (final === "J") {
+            ensure(row);
+            cells[row] = cells[row].slice(0, col);
+            cells.length = row + 1;
+          }
+          // "m" (styles) and anything else are invisible to the glyph grid.
+          continue;
+        }
+        if (token === "\n") { row += 1; col = 0; ensure(row); continue; }
+        if (token === "\r") { col = 0; continue; }
+        if (col >= columns) { wraps += 1; row += 1; col = 0; } // deferred autowrap
+        ensure(row);
+        cells[row][col] = token;
+        col += 1;
+      }
+    },
+    text() {
+      return cells.map((line) => Array.from(line, (ch) => ch ?? " ").join("")).join("\n");
+    },
+  };
+}
+
+function fakeTerminal({ columns = 80, rows = 24 } = {}) {
+  const screen = createScreen({ columns });
+  const stdout = { columns, rows, isTTY: true, write: (chunk) => { screen.write(chunk); return true; } };
+  const stdin = Object.assign(new EventEmitter(), {
+    isTTY: true,
+    isRaw: false,
+    setRawMode(value) { this.isRaw = value; },
+    resume() {},
+    pause() {},
+  });
+  const press = (...sequences) => { for (const s of sequences) stdin.emit("data", Buffer.from(s)); };
+  return { stdin, stdout, screen, press };
+}
+
+const OPTIONS = [{ label: "Alpha" }, { label: "Bravo" }, { label: "Charlie" }];
+
+// ---------------------------------------------------------------------------
+// (a) model picker rows render as name-only
+// ---------------------------------------------------------------------------
+
+test("model picker rows are the model name and nothing else", () => {
+  const models = modelsForProvider("cursor");
+  const options = modelPickerOptions(models);
+  assert.deepEqual(options, models.map((model) => ({ label: model.label })));
+  assert.equal(options[0].label, "Claude Fable 5 (thinking)");
+  assert.ok(options.every((option) => option.detail === undefined), "no detail line may ride along");
+
+  const lines = renderFrame({ title: "  most intelligent first", options, index: 0, width: 120, height: 24 })
+    .map(stripStyles);
+  assert.equal(lines[1], "  > 1. Claude Fable 5 (thinking)");
+  assert.equal(lines[3], "    3. GPT-5.6 Terra");
+  for (const line of lines) {
+    assert.doesNotMatch(line, /gpt-5\.6-terra-medium|thinking-medium/, "no model id slug in a row");
+    assert.doesNotMatch(line, /CursorBench/, "no benchmark score in a row");
+    assert.doesNotMatch(line, /best for/, "no 'best for …' copy in a row");
+    assert.doesNotMatch(line, /not in the .* snapshot/, "no unscored-model blurb in a row");
+  }
+});
+
+test("hosted model rows are also name-only — no server id, no blurb", () => {
+  const options = modelPickerOptions(HOSTED_MODELS);
+  assert.deepEqual(options, [{ label: "OX Alpha" }, { label: "GLM 5.2" }]);
+  const lines = renderFrame({ title: "  pick one", options, index: 1, width: 100, height: 24 }).map(stripStyles);
+  assert.equal(lines[1], "    1. OX Alpha");
+  assert.equal(lines[2], "  > 2. GLM 5.2");
+  for (const line of lines) {
+    assert.doesNotMatch(line, /stealth\/ox-alpha|z-ai\/glm/, "no server model id in a row");
+    assert.doesNotMatch(line, /free tier|default/, "no descriptor copy in a row");
+  }
+});
+
+// ---------------------------------------------------------------------------
+// (b) overflow: no wrapping, no paint residue
+// ---------------------------------------------------------------------------
+
+test("clipLine keeps short lines, ellipsizes long ones, and never counts styles", () => {
+  assert.equal(clipLine("plain", 10), "plain");
+  assert.equal(clipLine("exactly-10", 10), "exactly-10");
+  assert.equal(clipLine("longer than ten", 10), "longer th…");
+  // Styled text: the escape codes are free, the cut resets the style.
+  const styled = "\u001b[1mBold Name\u001b[0m and trailing text";
+  assert.equal(visibleLength(styled), "Bold Name and trailing text".length);
+  const clipped = clipLine(styled, 12);
+  assert.equal(stripStyles(clipped), "Bold Name a…");
+  assert.ok(clipped.endsWith("\u001b[0m"), "a clipped styled line must reset");
+});
+
+test("every frame line fits the terminal width, so no row can ever wrap", () => {
+  const options = [
+    { label: "Claude Fable 5 (thinking), an enormously long label that overflows" },
+    { label: "Short" },
+  ];
+  for (const width of [20, 30, 45]) {
+    const lines = renderFrame({ title: "  most intelligent first", options, index: 0, width, height: 24 });
+    for (const line of lines) {
+      assert.ok(visibleLength(line) <= width, `"${stripStyles(line)}" exceeds ${width} columns`);
+      assert.ok(!line.includes("\n"), "a frame line is exactly one physical line");
+    }
+  }
+});
+
+test("moving the selection past an overflowing row leaves no paint residue", async () => {
+  const long = "Bravo with an extremely long descriptor that overflows a narrow terminal by a lot";
+  const options = [{ label: "Alpha" }, { label: long }, { label: "Charlie" }];
+  const { stdin, stdout, screen, press } = fakeTerminal({ columns: 30, rows: 24 });
+
+  const picked = selectFrom({ title: "  pick", options, stdin, stdout });
+  press("j"); // onto the overflowing row
+  press("j"); // and past it — the old renderer left its wrapped tail here
+  const expected = renderFrame({ title: "  pick", options, index: 2, width: 30, height: 24 });
+  assert.equal(screen.text(), stripStyles(expected.join("\n")) + "\n", "the screen is exactly the current frame");
+  assert.equal(screen.wraps, 0, "no picker row may ever wrap");
+  assert.equal((screen.text().match(/>/g) ?? []).length, 1, "exactly one selection pointer survives a repaint");
+  assert.ok(!screen.text().includes("overflows a narrow"), "the overflowing tail was clipped, not wrapped");
+
+  press("\r");
+  assert.equal(await picked, 2);
+});
+
+test("a short terminal windows the list instead of overflowing it", async () => {
+  const options = [
+    { label: "One" }, { label: "Two" }, { label: "Three" }, { label: "Four" },
+    { label: "Five" }, { label: "Six" }, { label: "Seven" },
+  ];
+  const { stdin, stdout, screen, press } = fakeTerminal({ columns: 40, rows: 5 });
+  const picked = selectFrom({ title: "  pick", options, stdin, stdout });
+
+  for (let i = 0; i < 6; i++) press("\u001b[B"); // arrow down to "Seven"
+  const lines = screen.text().replace(/\n$/, "").split("\n");
+  assert.ok(lines.length <= 5, `the frame must fit 5 rows, got ${lines.length}`);
+  assert.ok(screen.text().includes("> 7. Seven"), "the selection stays visible in the window");
+
+  press("\r");
+  assert.equal(await picked, 6);
+});
+
+// ---------------------------------------------------------------------------
+// (c) arrows and j/k both move the selection — at any terminal size
+// ---------------------------------------------------------------------------
+
+test("arrow keys move the selection and wrap around, same as j/k", async () => {
+  const arrows = fakeTerminal();
+  const byArrows = selectFrom({ title: "t", options: OPTIONS, stdin: arrows.stdin, stdout: arrows.stdout });
+  arrows.press("\u001b[B", "\u001b[B", "\u001b[A", "\r"); // down down up
+  assert.equal(await byArrows, 1);
+
+  const vi = fakeTerminal();
+  const byVi = selectFrom({ title: "t", options: OPTIONS, stdin: vi.stdin, stdout: vi.stdout });
+  vi.press("j", "j", "k", "\r");
+  assert.equal(await byVi, 1);
+
+  const around = fakeTerminal();
+  const wrapped = selectFrom({ title: "t", options: OPTIONS, stdin: around.stdin, stdout: around.stdout });
+  around.press("\u001b[A", "\r"); // up from the top wraps to the bottom
+  assert.equal(await wrapped, 2);
+});
+
+test("arrows work in a tiny terminal too", async () => {
+  const { stdin, stdout, press } = fakeTerminal({ columns: 18, rows: 4 });
+  const picked = selectFrom({ title: "t", options: OPTIONS, stdin, stdout });
+  press("\u001b[B", "\u001b[B", "\r");
+  assert.equal(await picked, 2);
+});
+
+test("an arrow sequence split across reads still moves — it must not cancel", async () => {
+  const { stdin, stdout, press } = fakeTerminal();
+  const picked = selectFrom({ title: "t", options: OPTIONS, stdin, stdout });
+  press("\u001b"); // first read ends on the bare ESC byte…
+  press("[B");     // …the rest arrives on the next one
+  press("\r");
+  assert.equal(await picked, 1);
+});
+
+test("application-cursor-keys arrows (SS3, \\u001bOA) work as well", async () => {
+  const { stdin, stdout, press } = fakeTerminal();
+  const picked = selectFrom({ title: "t", options: OPTIONS, stdin, stdout });
+  press("\u001bOB", "\u001bOB", "\u001bOA", "\r");
+  assert.equal(await picked, 1);
+});
+
+test("a lone Escape still cancels once it is clearly not an arrow", async () => {
+  const { stdin, stdout, press } = fakeTerminal();
+  const picked = selectFrom({ title: "t", options: OPTIONS, stdin, stdout });
+  press("\u001b");
+  await sleep(80); // past the grace window that disambiguates ESC from ESC-[-A
+  assert.equal(await picked, null);
+});
+
+test("q cancels, enter selects, digits jump-select", async () => {
+  const q = fakeTerminal();
+  const cancelled = selectFrom({ title: "t", options: OPTIONS, stdin: q.stdin, stdout: q.stdout });
+  q.press("q");
+  assert.equal(await cancelled, null);
+
+  const digit = fakeTerminal();
+  const jumped = selectFrom({ title: "t", options: OPTIONS, stdin: digit.stdin, stdout: digit.stdout });
+  digit.press("3");
+  assert.equal(await jumped, 2);
+
+  const plain = fakeTerminal();
+  const defaulted = selectFrom({ title: "t", options: OPTIONS, defaultIndex: 1, stdin: plain.stdin, stdout: plain.stdout });
+  plain.press("\r");
+  assert.equal(await defaulted, 1);
+});
+
+test("parseKeys decodes whole, split, and batched sequences", () => {
+  assert.deepEqual(parseKeys("\u001b[A"), { keys: [{ name: "up", sequence: "\u001b[A" }], pending: "" });
+  assert.deepEqual(parseKeys("\u001bOB").keys.map((k) => k.name), ["down"]);
+  assert.deepEqual(parseKeys("j\u001b[Bk").keys.map((k) => k.name), ["j", "down", "k"]);
+  // Incomplete sequences are held for the next read, never misread as ESC.
+  assert.deepEqual(parseKeys("\u001b"), { keys: [], pending: "\u001b" });
+  assert.deepEqual(parseKeys("\u001b["), { keys: [], pending: "\u001b[" });
+  assert.deepEqual(parseKeys("j\u001b[").keys.map((k) => k.name), ["j"]);
+  // ESC followed by an ordinary byte is a real Escape press.
+  assert.deepEqual(parseKeys("\u001bx").keys.map((k) => k.name), ["escape", "x"]);
+});

--- a/packages/cli/test/skill.test.mjs
+++ b/packages/cli/test/skill.test.mjs
@@ -1,0 +1,57 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// The operational skill is the launch site for every Lighthouse cold/warm run:
+// prepareSession copies it into .makefaster/SKILL.md and every provider's agent
+// follows it verbatim. These tests pin the browser-isolation contract — the
+// measurement browser is a dedicated headless Chrome with its own profile,
+// never the user's everyday browser — so a future edit cannot quietly put
+// Lighthouse tabs back into the user's open Chrome.
+const SKILL_PATH = join(
+  resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", ".."),
+  "packages", "skill", "SKILL.md",
+);
+const SKILL = readFileSync(SKILL_PATH, "utf8");
+
+test("the Lighthouse launch site pins a dedicated headless Chrome with an isolated profile", () => {
+  const chromeFlags = [...SKILL.matchAll(/--chrome-flags="([^"]+)"/g)].map((m) => m[1]);
+  assert.ok(chromeFlags.length > 0, "the skill must spell out the Lighthouse chrome-flags");
+  for (const flags of chromeFlags) {
+    assert.ok(flags.includes("--headless=new"), `headless is mandatory, got: ${flags}`);
+    assert.match(flags, /--user-data-dir=\S*\.makefaster\//, `an isolated profile dir is mandatory, got: ${flags}`);
+    assert.ok(flags.includes("--no-first-run"), `--no-first-run is mandatory, got: ${flags}`);
+    assert.ok(flags.includes("--no-default-browser-check"), `--no-default-browser-check is mandatory, got: ${flags}`);
+  }
+});
+
+test("the skill never reuses an existing Chrome debugging port or the user's profile", () => {
+  // No example anywhere in the document may attach to an already-running
+  // Chrome — that is exactly how measurement tabs end up in the user's browser.
+  assert.doesNotMatch(SKILL, /lighthouse[^\n]*--port=\d/, "no Lighthouse example may attach by port");
+  assert.match(SKILL, /[Nn]ever pass `--port`/, "the port-reuse ban must be explicit");
+  assert.match(
+    SKILL,
+    /never `connect` or\s+`connectOverCDP` to a browser you did not start/,
+    "the Playwright/Puppeteer path must launch its own browser, not connect to the user's",
+  );
+  assert.match(
+    SKILL,
+    /must never attach to the user's everyday Chrome/,
+    "the isolation requirement must be stated as a rule, not implied",
+  );
+});
+
+test("CHROME_PATH still means our own headless launch with our own profile", () => {
+  assert.match(
+    SKILL,
+    /`CHROME_PATH`[^]*?still launch it headless with\s+the isolated `--user-data-dir`/,
+    "CHROME_PATH picks the binary; it must never mean reusing the user's session",
+  );
+});
+
+test("the isolation rule covers every measurement, cold and warm, baseline and re-measure", () => {
+  assert.match(SKILL, /cold and warm alike, baseline and re-measure alike/);
+});

--- a/packages/skill/SKILL.md
+++ b/packages/skill/SKILL.md
@@ -104,14 +104,44 @@ Use the heaviest-hitting **real, user-felt** metric you can actually measure
 on this machine, preferring:
 
 1. **Lighthouse** if available or installable
-   (`npx lighthouse <url> --output=json --quiet --chrome-flags="--headless=new"`)
-   — gives FCP / LCP / TBT / TTI / Speed Index in one run.
+   — gives FCP / LCP / TBT / TTI / Speed Index in one run. Launch it exactly
+   like this, every run:
+
+   ```sh
+   npx lighthouse <url> --output=json --quiet \
+     --chrome-flags="--headless=new --user-data-dir=./.makefaster/chrome-profile --no-first-run --no-default-browser-check"
+   ```
+
 2. Headless Chromium via **Playwright/Puppeteer** if the repo already has one
    — read `PerformanceNavigationTiming`, `largest-contentful-paint` entries,
-   and long tasks yourself.
+   and long tasks yourself. Launch the bundled headless browser
+   (`chromium.launch()` / `puppeteer.launch()`); never `connect` or
+   `connectOverCDP` to a browser you did not start.
 3. Last resort: **curl-level timings** (TTFB, full transfer time, total bytes
    of the entry page + critical assets). Weak, but honest — record that this
    is what you measured.
+
+### The measurement browser is never the user's browser
+
+The user may be working in their own Chrome while this loop runs. Measurement
+must never attach to the user's everyday Chrome: no new tabs in their windows,
+no shared profile, no attaching to their session. On every Lighthouse or
+DevTools-protocol run, cold and warm alike, baseline and re-measure alike:
+
+- Launch a **dedicated headless Chrome** (`--headless=new`) that this loop
+  starts and stops itself. That is what the `--chrome-flags` above guarantee;
+  they are a hard requirement, not a suggestion.
+- Give it an **isolated profile**: `--user-data-dir=./.makefaster/chrome-profile`
+  (under the session dir, already kept out of git; created on first launch).
+  Never launch against the user's default profile directory — a Chrome started
+  without its own `--user-data-dir` while the user's Chrome is running just
+  opens a tab in *their* browser.
+- Never pass `--port` to reuse an existing Chrome debugging port (9222 or any
+  other) unless that port belongs to a Chrome this loop launched itself. A
+  running debuggable Chrome you did not start is the user's; leave it alone.
+- If `CHROME_PATH` is set, use that binary — but still launch it headless with
+  the isolated `--user-data-dir` above. `CHROME_PATH` picks the executable,
+  never an existing browser session.
 
 Rules:
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes the three provider/model picker bugs Jacob hit, plus the follow-up: Lighthouse must never open tabs in the user's everyday Chrome.

## 1. Arrow keys dead in small terminals (j/k fine)

`selectFrom` matched whole stdin chunks byte-for-byte: only `"\u001b[A"`/`"\u001b[B"` counted as arrows, and a bare `"\u001b"` cancelled. Two real-world inputs broke that:

- An arrow sequence **split across reads** — which happens exactly when the terminal is busy, e.g. repainting a small wrapped window on every keypress — arrived as `ESC` then `[A`. The lone `ESC` chunk hit the cancel branch or was dropped.
- **Application-cursor-keys mode** arrows (`\u001bOA`, SS3) matched nothing at all. j/k are single bytes, so they always worked.

The picker now decodes input with an incremental parser (`parseKeys`): partial escape sequences are held for the next read, CSI and SS3 arrows both decode, and a lone ESC only cancels after a 50 ms grace window proves nothing followed it.

## 2. Ghosting when a row overflows the width

`render()` moved the cursor up by the *logical* line count then cleared below. A row wider than the terminal wraps onto 2+ physical lines, so the cursor never went up far enough and the stale wrapped tail survived every repaint. Now every frame line is clipped to the terminal width (ANSI-aware, ellipsized — picker rows never wrap), and the list is windowed to the terminal height so cursor-up can't clamp against the top of a short window. A repaint therefore covers exactly the lines the previous frame drew.

## 3. Model rows carried metadata

Both model pickers built rows as `label + dim(id)` plus a `detail` blurb (`CursorBench 70.5 — best for …`). Rows are now the model name only, via a shared `modelPickerOptions()` helper. The id is still confirmed right after the choice, and the ranked ordering ("most intelligent first") is unchanged.

## 4. Lighthouse never attaches to the user's Chrome

Every cold/warm measurement runs through the operational skill (`packages/skill/SKILL.md`, copied to `.makefaster/SKILL.md` for all four providers) — that's the launch site. It now pins the exact launch:

```
npx lighthouse <url> --output=json --quiet \
  --chrome-flags="--headless=new --user-data-dir=./.makefaster/chrome-profile --no-first-run --no-default-browser-check"
```

plus explicit rules: never pass `--port` to reuse a debugging port the loop didn't open, never `connect`/`connectOverCDP` Playwright/Puppeteer to a browser the loop didn't start, and `CHROME_PATH` picks the binary only — still launched headless with the isolated profile. The profile dir lives under `.makefaster/`, which the session already keeps out of git.

## Tests

- `test/picker.test.mjs` (13 tests) drives `selectFrom` through a small terminal emulator that models deferred autowrap, cursor-up, and clear-below, so paint residue is actually detectable: (a) model rows render name-only (no slug, no score, no "best for"), (b) an overflowing row never wraps and leaves zero residue when the selection moves at 30 columns (screen equals the current frame exactly), (c) arrows — whole, split across reads, and SS3 — and j/k all move the selection, including at 18×4.
- `test/skill.test.mjs` (4 tests) pins the browser-isolation contract at the launch site: headless + isolated `--user-data-dir` + first-run flags present in every `--chrome-flags` example, port-reuse and CDP-connect banned, CHROME_PATH handling stated, coverage of cold/warm/baseline/re-measure.
- Full suite: 202/202 pass (`npm test`).
- Also smoke-tested the picker through a real PTY at 25 columns: arrows traverse an overflowing row, rows clip with an ellipsis, repaints leave no residue.

Two-step end screen, CoT submit, charts, and the rest of the TUI behavior are untouched.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f7fb71c3-1d1c-4b43-a402-1c62c4c56f83?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f7fb71c3-1d1c-4b43-a402-1c62c4c56f83&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

