### PR TITLE
Trim the leaderboards, reposition the framed brackets, tidy the landing band, steps and corner marks

### DIFF
--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -376,9 +376,13 @@ site-header { display: block; }
 }
 .band-xhair.bottom { top: 100%; }
 
+/* The info panel is a column of the band, not a label beside it, so it takes
+   the same track width as the three metrics. minmax(0, ...) rather than a bare
+   1fr: a plain fr floors at min-content, which would let the widest chart or
+   the longest copy pull its own column wider than the rest. */
 .band-grid {
   display: grid;
-  grid-template-columns: 250px repeat(3, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
 .band-info {
@@ -909,7 +913,7 @@ site-header { display: block; }
   .stat-cards { grid-template-columns: repeat(2, 1fr); }
   /* The info panel takes a row of its own and the three metrics share the
      next one — three into two columns would leave a hole. */
-  .band-grid { grid-template-columns: repeat(3, 1fr); }
+  .band-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .band-info { grid-column: 1 / -1; border-bottom: 1px solid var(--line); }
   .metric:nth-child(2) { border-left: none; }
   .metric { border-top: 1px solid var(--hairline); }

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -198,8 +198,6 @@ site-header { display: block; }
   padding: 18px 0 6px;
   min-height: 74px;
 }
-/* No ref tab to make room for, so the row is just the gap above the content. */
-.georow--bare { min-height: 30px; }
 
 .ref-tab {
   font-family: var(--font-mono);

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -36,6 +36,7 @@ body {
   font-size: 16px;
   line-height: 1.5;
   min-height: 100vh;
+  padding-bottom: 48px;
   position: relative;
 }
 

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -771,18 +771,6 @@ site-header { display: block; }
 
 .site-url { font-size: 11.5px; color: var(--muted); }
 
-/* How much of the run was reusable technique. Deliberately the quietest thing
-   in the cell: it is context for the numbers, not one of them. */
-.site-keeps {
-  margin-top: 3px;
-  font-family: var(--font-mono);
-  font-size: 10px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: var(--muted);
-  opacity: 0.85;
-}
-
 .num-cell { font-family: var(--font-mono); font-weight: 600; font-size: 16px; color: var(--ink); }
 
 /* The pre-loop baseline sits beside the measurement it was beaten by, so it is

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -907,8 +907,8 @@ site-header { display: block; }
 .bracket { position: absolute; width: 16px; height: 16px; }
 .bracket.bl { left: -12px; bottom: 10px; border-left: 2px solid var(--red); border-bottom: 2px solid var(--red); }
 .bracket.br { right: -12px; bottom: 10px; border-right: 2px solid var(--red); border-bottom: 2px solid var(--red); }
-.sheet--framed .bracket.bl { left: -20px; bottom: -6px; }
-.sheet--framed .bracket.br { right: -20px; bottom: -6px; }
+.sheet--framed .bracket.bl { left: -46px; bottom: -12px; }
+.sheet--framed .bracket.br { right: -46px; bottom: -12px; }
 
 .page-end {
   height: 12px;

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -534,7 +534,13 @@ site-header { display: block; }
 .pictoframe .c.bl { bottom: 0; left: 0; border-bottom: 1.5px solid var(--ink); border-left: 1.5px solid var(--ink); }
 .pictoframe .c.br { bottom: 0; right: 0; border-bottom: 1.5px solid var(--ink); border-right: 1.5px solid var(--ink); }
 
-.step-arrow { align-self: start; margin-top: 40px; color: var(--red); }
+.step-arrow {
+  align-self: start;
+  margin-top: 40px;
+  color: var(--red);
+  position: relative;
+  left: -42px;
+}
 
 .step-label {
   font-family: var(--font-mono);

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -829,8 +829,6 @@ site-header { display: block; }
 
 .green-cell { font-family: var(--font-mono); font-weight: 700; font-size: 14.5px; letter-spacing: 0.08em; color: var(--green); }
 
-.sparkbars-cell { color: var(--green); }
-
 /* pagination ------------------------------------------------------------- */
 
 .table-foot {

--- a/frontend/js/format.js
+++ b/frontend/js/format.js
@@ -1,7 +1,6 @@
 /**
  * Small rendering helpers shared by the two leaderboard components:
- * escaping, the windowed pagination control, CSV export, and a seeded PRNG for
- * the decorative sparkbars.
+ * escaping, the windowed pagination control, and CSV export.
  */
 
 export function escapeHtml(value) {
@@ -86,16 +85,4 @@ export function downloadCsv(filename, header, rows) {
   a.click();
   document.body.removeChild(a);
   URL.revokeObjectURL(url);
-}
-
-/** Deterministic PRNG for stable decorative sparkbars. */
-export function mulberry32(seed) {
-  var a = seed >>> 0;
-  return function () {
-    a |= 0;
-    a = (a + 0x6d2b79f5) | 0;
-    var t = Math.imul(a ^ (a >>> 15), 1 | a);
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
-  };
 }

--- a/frontend/js/geo-row.js
+++ b/frontend/js/geo-row.js
@@ -2,15 +2,12 @@
  * The reference tab that sits between the masthead and the page content.
  * Light DOM, for the same reason as <site-header>.
  *
- * `<geo-row bare>` leaves the tab out. The row is then only the gap between
- * the masthead and the content, so it drops to the shorter `georow--bare`
- * height rather than reserving space for a tab that is not there.
+ * Only the landing page has one; the leaderboards open straight into their
+ * content.
  */
 class GeoRow extends HTMLElement {
   connectedCallback() {
-    this.innerHTML = this.hasAttribute("bare")
-      ? '<div class="georow georow--bare"></div>'
-      : `
+    this.innerHTML = `
       <div class="georow">
         <div class="ref-tab">REF: MF-001</div>
       </div>`;

--- a/frontend/js/improvement-leaderboard-page.js
+++ b/frontend/js/improvement-leaderboard-page.js
@@ -5,7 +5,6 @@
  * Light DOM so css/style.css keeps applying.
  */
 import "./site-header.js";
-import "./geo-row.js";
 import "./spec-footer.js";
 import { getImprovements } from "./api.js";
 import { escapeHtml, renderPagination, downloadCsv, mulberry32 } from "./format.js";
@@ -103,15 +102,7 @@ class ImprovementLeaderboardPage extends HTMLElement {
         <site-header></site-header>
 
         <div class="sheet-inner">
-          <geo-row></geo-row>
-
           <main>
-            <div class="eyebrow">
-              <span class="plus">+</span>
-              <span>Autonomous Performance Research / 001</span>
-              <span class="eyebrow-dots dots" aria-hidden="true"></span>
-            </div>
-
             <div class="page-head">
               <h1 class="page-title">Improvement Leaderboard</h1>
               <div class="page-sub">

--- a/frontend/js/improvement-leaderboard-page.js
+++ b/frontend/js/improvement-leaderboard-page.js
@@ -1,13 +1,13 @@
 /**
- * The improvement leaderboard: ranked categories with icons, decorative impact
- * sparkbars, pagination, and CSV export.
+ * The improvement leaderboard: ranked categories with icons, pagination, and
+ * CSV export.
  *
  * Light DOM so css/style.css keeps applying.
  */
 import "./site-header.js";
 import "./spec-footer.js";
 import { getImprovements } from "./api.js";
-import { escapeHtml, renderPagination, downloadCsv, mulberry32 } from "./format.js";
+import { escapeHtml, renderPagination, downloadCsv } from "./format.js";
 import { nextSort, sortRows, sortableHeader } from "./table-sort.js";
 
 const PER_PAGE = 12;
@@ -61,27 +61,6 @@ function iconMarkup(icon) {
     return '<img src="' + GENERATED_ICONS[icon] + '" alt="" width="21" height="21">';
   }
   return HAND_ICONS[icon] || HAND_ICONS.default;
-}
-
-/* Deterministic decorative histogram, scaled by impact. */
-function sparkbars(seed, pct) {
-  var rnd = mulberry32(0x6d66 + seed * 977);
-  var max = 18;
-  var scale = Math.min(1, Math.abs(pct) / 28.6);
-  var bars = [];
-  for (var i = 0; i < 11; i++) {
-    var decay = 1 - i * 0.062;
-    var h = max * (0.35 + 0.65 * scale) * decay * (0.7 + rnd() * 0.45);
-    h = Math.max(2, Math.min(max, h));
-    bars.push(
-      '<rect x="' + i * 4.4 + '" y="' + (max - h).toFixed(1) + '" width="2.6" height="' + h.toFixed(1) + '"/>'
-    );
-  }
-  return (
-    '<svg width="49" height="18" viewBox="0 0 49 18" fill="currentColor" aria-hidden="true">' +
-    bars.join("") +
-    "</svg>"
-  );
 }
 
 class ImprovementLeaderboardPage extends HTMLElement {
@@ -182,7 +161,7 @@ class ImprovementLeaderboardPage extends HTMLElement {
       })
       .catch(function (err) {
         self.els.tbody.innerHTML =
-          '<tr><td colspan="6" style="text-align:center;color:var(--red);padding:34px 16px;">' +
+          '<tr><td colspan="5" style="text-align:center;color:var(--red);padding:34px 16px;">' +
           "Could not load /data/improvements.json &mdash; start the server with ./run.sh (see README). " +
           "(" + escapeHtml(err.message) + ")</td></tr>";
       });
@@ -199,8 +178,7 @@ class ImprovementLeaderboardPage extends HTMLElement {
       '<th scope="col">Improvement Category</th>' +
       '<th scope="col">Description</th>' +
       sortableHeader(sort, "count", "Times Improved") +
-      sortableHeader(sort, "avgImprovementPct", "Avg Improvement") +
-      '<th scope="col"><span class="visually-hidden"></span></th>';
+      sortableHeader(sort, "avgImprovementPct", "Avg Improvement");
   }
 
   renderTable() {
@@ -215,7 +193,7 @@ class ImprovementLeaderboardPage extends HTMLElement {
 
     if (!data.length) {
       this.els.tbody.innerHTML =
-        '<tr><td colspan="6" style="text-align:center;color:var(--muted);padding:34px 16px;">' +
+        '<tr><td colspan="5" style="text-align:center;color:var(--muted);padding:34px 16px;">' +
         "No categories yet &mdash; the board fills up as loops submit their improvements." +
         "</td></tr>";
       this.els.showing.textContent = "Showing 0 improvement categories";
@@ -225,8 +203,8 @@ class ImprovementLeaderboardPage extends HTMLElement {
 
     this.els.tbody.innerHTML = pageRows
       .map(function (r, i) {
-        // The "#" column is the position in the order on screen; the server's
-        // own rank only seeds the sparkbars so they do not reshuffle on sort.
+        // The "#" column is the position in the order on screen, not the
+        // server's own rank.
         var position = start + i + 1;
         return (
           "<tr>" +
@@ -239,7 +217,6 @@ class ImprovementLeaderboardPage extends HTMLElement {
           '<td class="desc-cell">' + escapeHtml(r.description || "") + "</td>" +
           '<td class="count-cell">' + escapeHtml(fmt.format(r.count)) + "</td>" +
           '<td class="green-cell">' + escapeHtml(r.avgImprovementPct + "%") + "</td>" +
-          '<td class="sparkbars-cell">' + sparkbars(r.rank || position, r.avgImprovementPct) + "</td>" +
           "</tr>"
         );
       })

--- a/frontend/js/landing-page.js
+++ b/frontend/js/landing-page.js
@@ -108,8 +108,8 @@ class LandingPage extends HTMLElement {
   connectedCallback() {
     this.innerHTML = `
       <div class="sheet sheet--open">
+        <span class="corner-plus tl">+</span>
         <span class="corner-plus tr">+</span>
-        <span class="corner-plus ml">+</span>
 
         <site-header></site-header>
 

--- a/frontend/js/site-leaderboard-page.js
+++ b/frontend/js/site-leaderboard-page.js
@@ -5,7 +5,6 @@
  * Light DOM so css/style.css keeps applying.
  */
 import "./site-header.js";
-import "./geo-row.js";
 import "./spec-footer.js";
 import { getSites } from "./api.js";
 import { escapeHtml, renderPagination, downloadCsv } from "./format.js";
@@ -144,14 +143,7 @@ class SiteLeaderboardPage extends HTMLElement {
         <site-header></site-header>
 
         <div class="sheet-inner">
-          <geo-row bare></geo-row>
-
           <main>
-            <div class="eyebrow">
-              <span class="plus">+</span>
-              <span>Autonomous Performance Research / 001</span>
-            </div>
-
             <div class="page-head">
               <h1 class="page-title">Site leaderboard</h1>
             </div>

--- a/frontend/js/site-leaderboard-page.js
+++ b/frontend/js/site-leaderboard-page.js
@@ -51,22 +51,6 @@ const PR_GLYPH =
 const HTTP_URL = /^https?:\/\//i;
 
 /**
- * How the run's kept changes split between reusable techniques and findings
- * that only mattered to this site. A row with no split — every submission from
- * before the board recorded one, and every run that kept nothing — shows
- * nothing at all, rather than an honest-looking 0%.
- */
-function keepSplitMarkup(row) {
-  var generic = row.genericKeepPct;
-  var siteSpecific = row.siteSpecificKeepPct;
-  if (typeof generic !== "number" || generic + (siteSpecific || 0) <= 0) return "";
-  return (
-    '<div class="site-keeps" title="' + generic + '% of the kept changes were reusable techniques, ' +
-    (100 - generic) + '% were specific to this site">' + generic + "% generic</div>"
-  );
-}
-
-/**
  * The site's name, linked to the pull request that made it faster when the row
  * has one. Rows submitted before the board stored that link — and any run that
  * was not opened as a PR — stay plain text rather than pointing nowhere.
@@ -423,7 +407,7 @@ class SiteLeaderboardPage extends HTMLElement {
       cell.appendChild(self.faviconCell(r));
       var meta = document.createElement("div");
       meta.innerHTML =
-        siteNameMarkup(r) + '<div class="site-url">' + escapeHtml(r.url) + "</div>" + keepSplitMarkup(r);
+        siteNameMarkup(r) + '<div class="site-url">' + escapeHtml(r.url) + "</div>";
       cell.appendChild(meta);
       siteTd.appendChild(cell);
       tr.appendChild(siteTd);

--- a/frontend/js/site-leaderboard-page.js
+++ b/frontend/js/site-leaderboard-page.js
@@ -1,13 +1,13 @@
 /**
- * The site leaderboard: aggregate stat cards, a cold/warm filter, search, a
- * paginated table of sites, and CSV export.
+ * The site leaderboard: aggregate stat cards, a cold/warm filter, search, and a
+ * paginated table of sites.
  *
  * Light DOM so css/style.css keeps applying.
  */
 import "./site-header.js";
 import "./spec-footer.js";
 import { getSites } from "./api.js";
-import { escapeHtml, renderPagination, downloadCsv } from "./format.js";
+import { escapeHtml, renderPagination } from "./format.js";
 import { nextSort, sortRows, sortableHeader } from "./table-sort.js";
 
 const PER_PAGE = 10;
@@ -167,12 +167,6 @@ class SiteLeaderboardPage extends HTMLElement {
                   </svg>
                   <input type="search" id="site-search" placeholder="Search sites..." aria-label="Search sites">
                 </label>
-                <button type="button" class="btn-outline" id="export-csv">
-                  <svg class="icon" width="14" height="14" viewBox="0 0 15 15" fill="none" stroke="currentColor" stroke-width="1.3" aria-hidden="true">
-                    <path d="M7.5 1v8.5M4 6l3.5 3.5L11 6"></path><path d="M1.5 11v2.5h12V11"></path>
-                  </svg>
-                  <span>Export CSV</span>
-                </button>
               </div>
             </section>
 
@@ -206,7 +200,6 @@ class SiteLeaderboardPage extends HTMLElement {
       showing: this.querySelector("#sites-showing"),
       pagination: this.querySelector("#sites-pagination"),
       search: this.querySelector("#site-search"),
-      exportBtn: this.querySelector("#export-csv"),
       segmented: this.querySelectorAll(".segmented button"),
     };
 
@@ -244,28 +237,6 @@ class SiteLeaderboardPage extends HTMLElement {
       self.state.q = self.els.search.value;
       self.state.page = 1;
       self.renderTable();
-    });
-
-    this.els.exportBtn.addEventListener("click", function () {
-      downloadCsv(
-        "makefaster-sites-" + self.state.mode + ".csv",
-        [
-          "name", "url", "pr_url", "mode",
-          "lcp_before_ms", "lcp_after_ms", "lcp_improvement_pct",
-          "tti_before_ms", "tti_after_ms", "tti_improvement_pct",
-          "generic_keep_pct", "site_specific_keep_pct",
-          "tests", "measured_at",
-        ],
-        self.filtered().map(function (r) {
-          return [
-            r.name, r.url, r.prUrl || r.pr || "", r.mode,
-            r.lcpBefore, r.lcpRaw, r.lcpDelta,
-            r.ttiBefore, r.ttiRaw, r.ttiDelta,
-            r.genericKeepPct, r.siteSpecificKeepPct,
-            r.tests, r.measuredAt,
-          ];
-        })
-      );
     });
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Nine commits, each independently reviewable.

## 1. Both leaderboards open straight into their content

Supersedes the earlier "bare georow / drop eyebrow-dots" trim.

- **`<geo-row>` removed outright** from `site-leaderboard-page.js` and `improvement-leaderboard-page.js`, rather than kept as a `bare` variant. No empty spacer is left behind.
- **The whole `.eyebrow` block removed** from both pages — the `+`, the "Autonomous Performance Research / 001" line, and the dots — not just `.eyebrow-dots`.
- **`bare` support deleted.** The attribute and `.georow--bare { min-height: 30px }` existed for exactly one caller, the site leaderboard, and now have none. The landing page still renders the full row with its `REF: MF-001` tab.
- Dropped the now-unused `import "./geo-row.js"` from both leaderboard pages; the landing page imports it itself.

### On leaving no spacer

`.rail-dots` is absolutely positioned at `top: 100%` of the masthead, is 66px tall, and renders only on the framed leaderboard sheets — the geo row was reserving the space it hangs into, so this was worth checking before deleting the row.

Measured in headless Chrome against `main` at 18 widths from 375px to 1920px with the boards populated by fixture rows. Testing the rail against **glyph and control rects** rather than full-width container boxes found **zero collisions** at every width: the title glyphs end around x≈405–837 while the rail starts at x≈1291, so the rail only overlaps the empty right half of the full-width `.page-head` box. Below 720px the rail is already `display: none`.

The masthead-to-content gap goes to 0, but the `h1` line box supplies ~26px of leading above the cap height, so the title is not jammed against the rule.

[Site leaderboard before](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_site_leaderboard_before.png)
[Site leaderboard after](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_site_leaderboard_after.png)

## 2. `body` gets 48px of `padding-bottom`

The framed sheets previously ended flush with the bottom of the document, leaving nothing below the sheet border for anything to hang into. Body is `border-box` like everything else, so the padding comes out of the existing `min-height: 100vh` rather than adding to it: on a viewport tall enough for `min-height` to govern, `scrollHeight` is identical to `main` (2616px both), so no page gains a scrollbar. Space below the framed sheet goes 0px → 48px, and on landing 22px → 70px.

## 3. Framed bottom brackets moved out to the corners

```css
.sheet--framed .bracket.bl { left: -46px; bottom: -12px; }
.sheet--framed .bracket.br { right: -46px; bottom: -12px; }
```

Only the two framed overrides changed, and they already contained exactly `left`/`right` + `bottom`, so nothing else was disturbed — the 16px size and the 2px `var(--red)` borders come from the untouched base `.bracket` rules (verified as computed `16px x 16px` and `rgb(194, 64, 42)` after the change). There are no `.tl` / `.tr` bracket rules in the file, so no top brackets are involved, and the landing sheet's brackets keep their `-12px / 10px` placement.

[Bottom brackets before](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_bottom_brackets_before.png)
[Bottom brackets after](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_bottom_brackets_after.png)

### One thing to flag

At **1340px and below**, the sheet reaches the viewport edge and the bottom-left bracket lands at a negative x (`left: -1px` at 1340px, `-11px` at 1280px and under). Negative left overflow is not scrollable, so the bracket clips to a sliver at the viewport edge; the right bracket sits past the right edge, reachable only via the horizontal scroll that already exists. On `main` both brackets are fully visible at these widths.

I applied the offsets exactly as specified rather than guarding them with a breakpoint — happy to add one if you want the brackets to pull back in on narrower viewports.

[Bottom-left bracket clipped at 1280px](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_bottom_bracket_clipped_at_1280.png)

## 4. The sparkbar column is gone from the improvement leaderboard

The bars were seeded from each row's rank and scaled by its improvement percentage, so they looked like a distribution while carrying no measurement at all — worse than no chart, since a reader cannot tell by looking. The real data is in the two columns to their left.

Removed the header, the cell, the `sparkbars()` builder, the `mulberry32` PRNG in `format.js` that only fed it (no other caller, no test coverage; `scripts/generate-data.mjs` has its own local copy and is untouched), and the `.sparkbars-cell` colour rule.

The trailing header was an empty `<th>` wrapping a `.visually-hidden` span with no text, and nothing in the stylesheet defines that class, so it went with the column. Both the empty-state and error-state message rows drop to `colspan="5"`.

Verified in headless Chrome: 5 headers and 5 cells per row, zero stray `<svg>` in the tbody outside the legitimate category icons (12 still render), sorting still reorders with the header indicator flipping ▼ → ▲, pagination still works, and both message rows report `colspan="5"` and measure to the full table width.

[Improvement leaderboard with the sparkbar column removed](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_improvement_table_no_sparkbars.png)

## 5. The keep-split badge is gone from the site leaderboard

The `.site-keeps` badge ("80% generic") sat under each site's URL as a third line of type in a cell that already carries a name and a domain, and it answered a question about the run rather than about the site's speed, which is what the board ranks.

Removed the markup, the `keepSplitMarkup()` builder, and the `.site-keeps` rule, which nothing else used. **The data is untouched:** submissions still accept the fields and `/data/sites.json` still returns them.

In the DOM there are now zero `.site-keeps` elements, zero occurrences of "% generic" text, and zero `title` attributes mentioning the split. The site cell is down to favicon, name, and URL.

[Site cell with the keep-split badge](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_site_keeps_before.png)
[Site cell after removing the keep-split badge](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_site_keeps_after.png)

## 6. The site leaderboard's CSV export is gone

Removed the button, its click handler, and the row-to-column mapping only that handler used, plus `downloadCsv` from this page's import list.

**The improvement board keeps its export**, so the shared pieces stay: `downloadCsv()` remains in `format.js` and `.btn-outline` remains in the stylesheet, each with that button as its remaining caller. `filtered()` also stays — the export used it, but so does `renderTable()`.

The button shared `.controls-right` with the search box, so the wrapper stays and the search keeps its place at the right edge of the controls row (its right edge measures 1345px, flush with the controls row's own).

Verified in headless Chrome. On the site board: no `#export-csv`, no `.btn-outline`, no "Export CSV" text anywhere on the page, and the rest of the controls still work — search filters to 1 row and clears back to "Showing 1 to 10 of 11 sites", and the cold/warm toggle switches correctly. On the improvement board the button is still present, still styled by `.btn-outline`, and I captured its export blob: header `rank,name,description,times_improved,avg_improvement_ms,avg_improvement_pct` with 13 data rows and correct quoting of a description containing a comma.

[Site leaderboard controls without the export button](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_site_controls_no_export.png)

## 7. Every landing band column is the same width

`.band-grid` pinned the info panel to `250px` and let the three metrics split what was left, so the panel came out 84px narrower than its neighbours and read as a caption attached to the band rather than the first of four columns. It is now `repeat(4, minmax(0, 1fr))`.

`minmax(0, 1fr)` rather than a bare `1fr`, because a plain `fr` is `minmax(auto, 1fr)` and floors at min-content — the chart columns and the panel's own copy could each argue their track wider than an equal share, which is exactly the failure being fixed.

Measured at 13 widths from 375px to 1920px, comparing every child's rendered box against `main`:

| | `main` | this branch |
|---|---|---|
| 1440px tracks | `250px 334px 334px 334px` | `313px 313px 313px 313px` |
| 1180px tracks | `250px 287px 287px 287px` | `278px 278px 278px 278px` |
| spread within the row | up to 84px | under 1.5px at every width |

The tablet and narrow behaviour is unchanged: at ≤1100px the panel still spans its own row with the three metrics equal beneath it, and at ≤720px everything is a single column. Those breakpoints measure identically to `main`. I gave the three-metric row the same `minmax(0, ...)` floor so its tracks are guaranteed equal too. No cell's content overflows its track at any width tested.

One incidental improvement: with the panel 63px wider, "DATASET: PUBLIC SITE LEADERBOARD" now fits on one line instead of wrapping to three, so the band is slightly shorter.

[Landing band with a narrow info column](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_band_grid_before.png)
[Landing band with four equal columns](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_band_grid_after.png)
[Landing band tablet stacking preserved](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_band_grid_tablet_stacking.png)

## 8. The step arrows sit between the pictoframes

```css
.step-arrow {
  align-self: start;
  margin-top: 40px;
  color: var(--red);
  position: relative;
  left: -42px;
}
```

The arrows sat hard against the next frame's bracket rather than in the gap between the two frames they connect; the offset centres them there.

The rule previously held exactly `align-self`, `margin-top`, and `color`, all three of which the new block already specifies, so nothing was dropped — `color` in particular still matters, since the arrow strokes with `currentColor`. A relative offset rather than a track change keeps the grid untouched: the arrows are the `auto` columns of `.steps`, so the four steps keep their widths.

Measured at 10 widths from 480px to 1920px against `main`: the arrows shift left by exactly 42px (at 1440px, 564→522, 828→786, 1092→1050) and collide with nothing — I compared each arrow against the glyph rects of every `.step-label` and `.step p` plus every `.pictoframe` box, and got zero intersections at every width. The `.steps` container has no overflow, and the `@media (max-width: 1100px)` rule that hides the arrows is untouched (confirmed `display: none` at 1100px, where the grid switches to two columns).

[Step arrows hugging the next frame](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_step_arrows_before.png)
[Step arrows centred between frames](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_step_arrows_after.png)

## 9. The landing sheet's plusses bracket the masthead

The open sheet carried one plus top-right and one halfway down the left edge (`tr` and `ml`), so the pair read as two unrelated marks rather than registration marks bracketing the masthead. It is now `tl` and `tr`, with no `bl` / `br` added.

Markup only — all four `.corner-plus` position rules stay in the stylesheet, because the framed leaderboard sheets still use `tl`, `tr`, `ml` and `mr`.

Verified across all three routes at 1440px, 1100px and 720px: landing reports exactly `["tl", "tr"]`, both with real CSS offsets (`tl` at x=38, `tr` at x=1393, both at y=28, a symmetric pair), and both leaderboards still report `["tl", "tr", "ml", "mr"]` at identical coordinates to `main`. The eyebrow's own inline `+` is a separate element and is untouched.

[Landing corner marks before](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_corner_plus_before.png)
[Landing corner marks after](https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fscreenshot_corner_plus_after.png)

## Notes

Separately, the boards report a horizontal scrollbar at ≤1280px. That is pre-existing and unrelated — identical on `main`, and present on landing too (the corner registration plusses sit 22px outside the sheet). The bracket move does not widen it; `scrollWidth` is unchanged from `main` at every width tested.

No console or page errors on any of the three routes. `npm test` passes, 196/196.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ee6a53c8-f3d5-4852-aca1-fd15ebe01bac&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

