### PR TITLE
Serve the site leaderboard's favicons from makefaster.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ Every variable has a working default, so an empty `.env` boots. See
 | `MIGRATIONS_DIR` | `./internal/db/migrations` | goose migrations, applied on start |
 | `SEED_DIR` | `../data` | seed JSON, read only into empty tables; the committed default is empty |
 | `FRONTEND_DIR` | `../frontend` | SPA static root |
+| `MAKEFASTER_FAVICON_DIR` | `/var/lib/makefaster/favicons` | where downloaded site favicons are stored; outside the repo, `off` to serve none (see [Site favicons](#site-favicons)) |
 | `MAKEFASTER_EMBEDDINGS_API_KEY` / `OPENAI_API_KEY` | — | switches the embedder from local to a remote OpenAI-compatible endpoint |
 | `MAKEFASTER_EMBEDDINGS_MODEL` | `text-embedding-3-small` | remote embedding model |
 | `MAKEFASTER_EMBEDDINGS_BASE_URL` | `https://api.openai.com/v1` | any OpenAI-compatible host |
@@ -361,6 +362,7 @@ start empty and grow as loops report results:
 |----------|------|---------|
 | `GET /data/sites.json` | live site rows, one per site per load mode | `MakefasterAPI.getSites()` |
 | `GET /data/improvements.json` | live ranked categories | `MakefasterAPI.getImprovements()` |
+| `GET /favicons/<site>-<id>.png` | one site's favicon, downloaded from its own origin once and normalized — the only image URL the board loads (see [Site favicons](#site-favicons)) | — |
 | `GET /api/health` | `{ ok, embedder, threshold }` | — |
 | `POST /api/submit-site` | `{ url, favicon?, name?, prUrl?, genericKeepPct?, siteSpecificKeepPct?, tips?, lcpBefore?, lcpRaw, lcpDelta, ttiBefore?, ttiRaw, ttiDelta, mode: cold\|warm }` — upserts the site's row; URL + favicon shown publicly, `name` reduced to the product's own name, `prUrl` (or `pr`) linked from it. `tips` is up to 10 `{ text, about? }` notes to the catalog maintainers (280/80 chars, clamped): stored privately, acknowledged only as a count, never served by any endpoint | `MakefasterAPI.submitSite(payload)` |
 | `POST /api/submit-improvements` | `{ improvements: [{ name, description?, deltaMs?, deltaPct? }] }` — anonymous; names and descriptions are normalized to generic techniques and embedding-matched into categories | `MakefasterAPI.submitImprovements(payload)` |
@@ -402,6 +404,52 @@ folded a new run into an existing one, both as `{ ok, created, row }`; invalid
 payloads come back as `400 { ok: false, errors: [...] }`. Writes are serialized,
 POSTs are rate limited to 60/minute/IP, bodies are capped at 256 KB, and every
 response carries permissive CORS so the SPA can be hosted anywhere.
+
+### Site favicons
+
+The board used to point `<img src>` straight at `row.favicon`, which is a URL on
+somebody else's server — and plenty of them refuse an image request that comes
+from a page on another domain. Hotlink protection, a cross-origin 403, a
+redirect to an HTML error page: the row showed a broken image where an icon
+belonged.
+
+So the server keeps its own copy
+([`backend/internal/favicon`](backend/internal/favicon)):
+
+- **downloaded once**, on ingest (`POST /api/submit-site` knows the URL first)
+  or on the first board render that needs it, from the submitted or derived
+  favicon URL;
+- **normalized** to one size and one format — a **64px square PNG**, fitted and
+  centred on transparency so a wide icon is not stretched, which is exactly what
+  the board's 28px `.favicon-box` draws at 26px on a 2x display. ICO (including
+  the bare Windows bitmaps inside it), PNG, JPEG and GIF are read; an SVG or
+  WebP favicon is not, and falls back;
+- **stored under `MAKEFASTER_FAVICON_DIR`**, outside the repo and outside
+  `FRONTEND_DIR`, so a git pull cannot clobber the cache and the static handler
+  cannot serve whatever else lands in it;
+- **served from `/favicons/<site>-<digest of the source URL>.png`** with a
+  day-long `max-age`. Same origin as the board, so no CORS and no referrer
+  policy is involved; the digest in the name is what makes a row that starts
+  pointing at a different icon get a different path rather than a stale file.
+
+Nothing waits on a download. `GET /data/sites.json` starts the ones it needs and
+answers at the speed of the database, so an origin's slow CDN cannot slow the
+board down; the row carries the served path as `faviconPath` alongside the
+original `favicon`, and until the file lands — or when the fetch fails outright
+— the board draws the site's initial, which is what a row with no favicon has
+always done. A failed URL is left alone for ten minutes rather than retried on
+every render, and a stored icon is refreshed in the background after two weeks
+while the old one keeps being served.
+
+Two things this deliberately does not do: it does not fetch a URL that is not
+absolute `http(s)`, and it **does not connect to a non-public address**. The
+favicon URL arrives through a public write endpoint, so a server that would
+fetch `http://169.254.169.254/…` on request is an SSRF hole; the check runs on
+the resolved address, which is what makes it survive a hostname that points at
+loopback and a redirect chain that ends there.
+
+`MAKEFASTER_FAVICON_DIR=off` turns the whole thing off: no route, no
+`faviconPath`, letters on the board. It never falls back to hotlinking.
 
 ### The hosted model proxy
 
@@ -603,7 +651,10 @@ Row shapes:
 // prUrl is the pull request the run was opened as, and is absent when the row
 // has none — the board links the site name to it when it is there. The two keep
 // percentages are absent together when the run reported no split.
+// favicon is the icon at its own origin; faviconPath is this server's
+// normalized copy of it, and the only one the board loads.
 { "name": "Example", "url": "example.com", "favicon": "https://…",
+  "faviconPath": "/favicons/example.com-9f2c1b7d04.png",
   "prUrl": "https://github.com/jjcm/example/pull/1",
   "genericKeepPct": 80, "siteSpecificKeepPct": 20,
   "lcpBefore": 2791, "lcpRaw": 1842, "lcpDelta": -34,
@@ -646,7 +697,10 @@ needs `MARIADB_DSN`, `FRONTEND_DIR`, and `MIGRATIONS_DIR` pointing at the
 shipped copies of `frontend/` and `backend/internal/db/migrations/`. If it is to
 collect [chains of thought](#chains-of-thought) it also needs write access to
 `MAKEFASTER_TRACE_DIR` — somewhere private, outside `FRONTEND_DIR`, and it is
-not backed up by anything that publishes. Put a
+not backed up by anything that publishes. `MAKEFASTER_FAVICON_DIR` wants write
+access too, for the opposite reason: those bytes are public
+([site favicons](#site-favicons)), and they only need to live somewhere a
+deploy will not overwrite. Put a
 TLS-terminating proxy (Caddy/nginx/Cloudflare) in front and point the domain at
 it — the `npx makefaster` CLI submits to `https://makefaster.dev` by default,
 and elsewhere with `--api` or `MAKEFASTER_API_BASE`.
@@ -665,8 +719,16 @@ server too so the boards stay live.
 npm test                                    # CLI: detection, args, payloads,
                                             # protocol children, catalog, dashboard,
                                             # the end screen's questions
-cd backend && go test ./...                 # server, embedder, categorization, traces
+cd backend && go test ./...                 # server, embedder, categorization,
+                                            # traces, favicons
 ```
+
+The favicon suite serves its own origin with `httptest` and never touches the
+internet: an unfetchable URL, an origin that refuses the request, an origin that
+answers 200 with an HTML page, a successful convert down to the served pixels, a
+second request that is a file read rather than a second download, a stale file
+served while it refreshes behind the request, eight concurrent viewers sharing
+one download, and the private-address guard refusing a loopback origin.
 
 The CLI suite spawns real protocol children — a stub agent speaking ACP and one
 speaking the codex app-server dialect — and asserts on the frames they receive,

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -16,6 +17,7 @@ import (
 	"makefaster/internal/config"
 	"makefaster/internal/db"
 	"makefaster/internal/embedding"
+	"makefaster/internal/favicon"
 	httpapi "makefaster/internal/http"
 	"makefaster/internal/inference"
 	"makefaster/internal/store"
@@ -74,6 +76,12 @@ func main() {
 	// endpoint answers 503 and the reason is logged once, here.
 	traces := openTraceVault(cfg, pool, logger)
 
+	// The board's icons, downloaded from each site's own origin and served from
+	// here. Also not a reason to refuse to boot: without it the board shows
+	// each site's initial, which is what it already does for a row with no
+	// favicon at all.
+	favicons := openFaviconCache(cfg, leaderboards, logger)
+
 	server := httpapi.NewServer(httpapi.Options{
 		Store:       leaderboards,
 		Embedder:    embedder,
@@ -82,6 +90,7 @@ func main() {
 		Logger:      logger,
 		Inference:   models,
 		Traces:      traces,
+		Favicons:    favicons,
 	})
 
 	logger.Info("makefaster server listening",
@@ -122,4 +131,41 @@ func openTraceVault(cfg config.Config, pool *sql.DB, logger *slog.Logger) *trace
 	logger.Info("chain-of-thought traces are stored privately and served by nothing",
 		"traceDir", vault.Dir())
 	return vault
+}
+
+// openFaviconCache prepares the directory the site leaderboard's icons are
+// downloaded into, or returns nil when this deployment serves none.
+//
+// The configured directory is deliberately outside the repo, which on a
+// developer's machine usually means somewhere unwritable. Rather than dropping
+// the icons from every local board, an unwritable directory falls back to a
+// cache under the system temporary directory: these files are derived from
+// public URLs and are re-downloadable, so losing them on reboot costs nothing.
+// A deployment that wants them to survive one sets MAKEFASTER_FAVICON_DIR.
+func openFaviconCache(cfg config.Config, leaderboards *store.Store, logger *slog.Logger) *favicon.Cache {
+	if !cfg.FaviconsEnabled() {
+		logger.Info("site favicons are off; the board will show each site's initial",
+			"faviconDir", cfg.FaviconDir)
+		return nil
+	}
+	options := favicon.Options{
+		Dir:      cfg.FaviconDir,
+		Resolver: leaderboards.SiteFavicon,
+		Logger:   logger,
+	}
+	cache, err := favicon.New(options)
+	if err != nil {
+		fallback := filepath.Join(os.TempDir(), "makefaster-favicons")
+		logger.Warn("could not prepare the favicon directory; using a temporary one",
+			"faviconDir", cfg.FaviconDir, "fallback", fallback, "error", err)
+		options.Dir = fallback
+		if cache, err = favicon.New(options); err != nil {
+			logger.Warn("could not prepare a favicon directory; the board will show each site's initial",
+				"faviconDir", fallback, "error", err)
+			return nil
+		}
+	}
+	logger.Info("site favicons are downloaded from each origin once and served from this one",
+		"faviconDir", cache.Dir(), "route", favicon.URLPrefix, "size", favicon.Size)
+	return cache
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -23,6 +23,13 @@ const (
 	// MAKEFASTER_TRACE_DIR to "off" turns collection off entirely.
 	DefaultTraceDir = "/var/lib/makefaster/traces"
 
+	// Where the site leaderboard's favicons are downloaded, normalized and
+	// served from. Outside the repo and outside FRONTEND_DIR so a deploy or a
+	// git pull cannot clobber the cache; it is served by its own route rather
+	// than by the static handler. Setting MAKEFASTER_FAVICON_DIR to "off"
+	// turns the whole feature off, and the board draws letters instead.
+	DefaultFaviconDir = "/var/lib/makefaster/favicons"
+
 	DefaultEmbeddingsModel   = "text-embedding-3-small"
 	DefaultEmbeddingsBaseURL = "https://api.openai.com/v1"
 
@@ -64,6 +71,7 @@ type Config struct {
 	FrontendDir   string
 	SeedDir       string
 	TraceDir      string
+	FaviconDir    string
 	Embeddings    Embeddings
 	Inference     Inference
 }
@@ -73,6 +81,13 @@ type Config struct {
 // POST /api/submit-trace answers 503 saying so.
 func (c Config) TracesEnabled() bool {
 	return c.TraceDir != "" && !strings.EqualFold(c.TraceDir, "off")
+}
+
+// FaviconsEnabled reports whether this deployment downloads and serves site
+// favicons itself. Off means the board falls back to each site's initial — it
+// never hotlinks the origin's icon, which is the thing this replaced.
+func (c Config) FaviconsEnabled() bool {
+	return c.FaviconDir != "" && !strings.EqualFold(c.FaviconDir, "off")
 }
 
 // Addr is the host:port passed to net/http.
@@ -90,6 +105,7 @@ func Load() Config {
 		FrontendDir:   envString("FRONTEND_DIR", DefaultFrontendDir),
 		SeedDir:       envString("SEED_DIR", DefaultSeedDir),
 		TraceDir:      envString("MAKEFASTER_TRACE_DIR", DefaultTraceDir),
+		FaviconDir:    envString("MAKEFASTER_FAVICON_DIR", DefaultFaviconDir),
 		Embeddings:    loadEmbeddings(),
 		Inference:     loadInference(),
 	}

--- a/backend/internal/favicon/cache.go
+++ b/backend/internal/favicon/cache.go
@@ -1,0 +1,606 @@
+// Package favicon serves the site leaderboard's icons from this origin instead
+// of hotlinking them.
+//
+// A submitted (or derived) favicon URL points at somebody else's server, and
+// plenty of them refuse the request once it comes from a page on another
+// domain — hotlink protection, a CORS-flavoured 403, a redirect to an HTML
+// error page. The board then showed a broken image where an icon belonged.
+//
+// So the server downloads the icon once, normalizes it to one size and one
+// format (Size x Size PNG), stores the bytes in a writable data directory
+// outside the repo, and serves that file under URLPrefix. The page only ever
+// asks this origin for an image, which needs no CORS and cannot be hotlink
+// blocked.
+//
+// Three properties the rest of the server leans on:
+//
+//   - Nothing blocks on a download. Prime is fire-and-forget, so
+//     GET /data/sites.json answers at the speed of the database no matter how
+//     slow an origin's CDN is, and the board's existing letter fallback covers
+//     the gap until the file lands.
+//   - A file's name carries a digest of the URL it came from, so a row that
+//     starts pointing somewhere new gets a new path rather than a stale icon.
+//   - A failure is not an error the page has to handle. Serve answers 404, the
+//     row draws its letter, and the URL is left alone for a cooldown instead of
+//     being retried on every render.
+package favicon
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// URLPrefix is where the served icons live. Same origin as the board, so an
+// <img> needs no CORS headers and no referrer policy to load one.
+const URLPrefix = "/favicons/"
+
+const (
+	// DefaultTTL is how long a stored icon is used before it is refreshed in
+	// the background. Favicons change on the order of a rebrand, so this is
+	// long; the stale file keeps being served while the refresh runs.
+	DefaultTTL = 14 * 24 * time.Hour
+
+	// A favicon that does not fit in a megabyte is not a favicon.
+	maxDownloadBytes = 1 << 20
+
+	fetchTimeout = 8 * time.Second
+
+	// How long a URL that failed is left alone. Without it, a board render
+	// re-downloads every broken icon on the page, every time.
+	failureCooldown = 10 * time.Minute
+
+	maxRedirects = 3
+
+	// Background downloads run on a small budget so a first render of a large
+	// board cannot open one connection per row. Priming is best-effort: over
+	// budget, the icon waits for the next render or for the request the browser
+	// makes for it.
+	backgroundFetches = 4
+
+	// A crude ceiling on the failure map, swept wholesale like the HTTP
+	// rate limiter's buckets rather than entry by entry.
+	maxFailureEntries = 10_000
+
+	digestLength = 10
+
+	userAgent = "makefaster-favicon/1.0 (+https://makefaster.dev)"
+)
+
+// ErrDisabled is returned by New when no directory is configured: a deployment
+// that cannot (or does not want to) cache icons serves none, and the board
+// falls back to letters.
+var ErrDisabled = errors.New("favicon storage is not configured")
+
+// ErrUnfetchableURL is a source URL this server will not request — a
+// non-http(s) scheme, or nothing that parses as an absolute URL.
+var ErrUnfetchableURL = errors.New("not a fetchable http(s) URL")
+
+var errCoolingOff = errors.New("this favicon URL failed recently")
+
+// A dotted hostname of sane DNS labels, matching what ingest normalizes a
+// submitted site URL down to (leaderboard.NormalizeSiteURL). It is repeated
+// here rather than imported because it is doing a different job: keeping a
+// requested path from naming a file outside the cache directory.
+var hostPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$`)
+
+var digestPattern = regexp.MustCompile(`^[0-9a-f]+$`)
+
+// Resolver answers "which favicon URL is this site's row pointing at right
+// now?". It is the store lookup, injected so this package stays testable
+// without a database.
+//
+// An empty string means the site has none, which is not an error.
+type Resolver func(ctx context.Context, host string) (string, error)
+
+type Options struct {
+	// Dir is the writable directory the normalized icons are stored in.
+	// Deliberately outside the repo and outside FRONTEND_DIR: a git pull must
+	// not be able to delete the cache, and the static handler must not be able
+	// to serve whatever else ends up in it.
+	Dir string
+
+	Resolver Resolver
+	Logger   *slog.Logger
+
+	// TTL overrides DefaultTTL. Mostly here so a test can make a stored file
+	// stale without touching the clock.
+	TTL time.Duration
+
+	// AllowPrivateHosts lifts the private-address guard. Only a test serving
+	// its own upstream on 127.0.0.1 should set it: in production the URL being
+	// fetched is attacker-supplied, and a server that will fetch
+	// http://10.0.0.1/ on request is an SSRF hole.
+	AllowPrivateHosts bool
+
+	// Client overrides the HTTP client used for downloads.
+	Client *http.Client
+}
+
+// Cache is the store-and-serve half of the feature: a directory of normalized
+// PNGs plus the bookkeeping that keeps one URL from being downloaded twice at
+// once or retried on every render after it fails.
+type Cache struct {
+	dir     string
+	ttl     time.Duration
+	client  *http.Client
+	resolve Resolver
+	logger  *slog.Logger
+
+	slots chan struct{}
+
+	mu       sync.Mutex
+	inflight map[string]*download
+	failed   map[string]time.Time
+}
+
+// download is one in-flight fetch, so concurrent viewers of the same row share
+// a single request instead of racing to write the same file.
+type download struct {
+	done chan struct{}
+	data []byte
+	err  error
+}
+
+// New prepares the cache directory.
+//
+// The directory is 0755 and the files 0644, unlike the trace vault's 0700/0600:
+// these bytes are public by design — they are what the board shows — and the
+// only thing that matters is that they live somewhere a deploy will not
+// overwrite.
+func New(opts Options) (*Cache, error) {
+	if strings.TrimSpace(opts.Dir) == "" {
+		return nil, ErrDisabled
+	}
+	absolute, err := filepath.Abs(opts.Dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve favicon dir: %w", err)
+	}
+	if err := os.MkdirAll(absolute, 0o755); err != nil {
+		return nil, fmt.Errorf("create favicon dir %s: %w", absolute, err)
+	}
+
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	ttl := opts.TTL
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	client := opts.Client
+	if client == nil {
+		client = newClient(opts.AllowPrivateHosts)
+	}
+	return &Cache{
+		dir:      absolute,
+		ttl:      ttl,
+		client:   client,
+		resolve:  opts.Resolver,
+		logger:   logger,
+		slots:    make(chan struct{}, backgroundFetches),
+		inflight: map[string]*download{},
+		failed:   map[string]time.Time{},
+	}, nil
+}
+
+// Dir is the storage root, for the log line that says where icons are going.
+func (c *Cache) Dir() string { return c.dir }
+
+// Path is the same-origin URL for a site's icon, or "" when there is nothing
+// to serve — no favicon URL, or one this server will not fetch. The board
+// renders its letter fallback in that case rather than hotlinking.
+func (c *Cache) Path(host, sourceURL string) string {
+	name := fileName(host, sourceURL)
+	if name == "" {
+		return ""
+	}
+	return URLPrefix + name
+}
+
+// Prime starts a download when the stored file is missing or stale, and returns
+// immediately either way. Nothing waits on the result: a slow origin must not
+// be able to slow down the board.
+func (c *Cache) Prime(host, sourceURL string) {
+	name := fileName(host, sourceURL)
+	if name == "" {
+		return
+	}
+	if fresh, _ := c.stored(name); fresh {
+		return
+	}
+	if c.coolingOff(name) {
+		return
+	}
+	select {
+	case c.slots <- struct{}{}:
+	default:
+		return
+	}
+	go func() {
+		defer func() { <-c.slots }()
+		ctx, cancel := context.WithTimeout(context.Background(), fetchTimeout)
+		defer cancel()
+		if _, err := c.fetchOnce(ctx, name, sourceURL); err != nil && !errors.Is(err, errCoolingOff) {
+			c.logger.Info("favicon not stored", "site", host, "source", sourceURL, "error", err)
+		}
+	}()
+}
+
+// ServeHTTP answers GET/HEAD URLPrefix<host>-<digest>.png.
+//
+// A hit is a file read. A miss downloads the icon inline — bounded by the fetch
+// timeout, and shared with anyone else asking for the same one — because the
+// browser asking for this image is exactly the moment the bytes are needed. A
+// miss that cannot be filled is a 404, which the board already handles.
+func (c *Cache) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	host, ok := parseName(strings.TrimPrefix(r.URL.Path, URLPrefix))
+	if !ok {
+		c.writeMiss(w)
+		return
+	}
+	name := strings.TrimPrefix(r.URL.Path, URLPrefix)
+
+	// The digest in the path has to match the URL the row carries now, or the
+	// link is one a stale board render handed out.
+	source := c.sourceFor(r.Context(), host)
+	if source != "" && fileName(host, source) != name {
+		source = ""
+	}
+
+	if data, modTime, err := c.read(name); err == nil {
+		if source != "" && time.Since(modTime) > c.ttl {
+			c.Prime(host, source)
+		}
+		c.writeImage(w, r, name, modTime, data)
+		return
+	}
+	if source == "" {
+		c.writeMiss(w)
+		return
+	}
+
+	data, err := c.fetchOnce(r.Context(), name, source)
+	if err != nil {
+		c.writeMiss(w)
+		return
+	}
+	c.writeImage(w, r, name, time.Now(), data)
+}
+
+func (c *Cache) sourceFor(ctx context.Context, host string) string {
+	if c.resolve == nil {
+		return ""
+	}
+	source, err := c.resolve(ctx, host)
+	if err != nil {
+		c.logger.Error("favicon lookup failed", "site", host, "error", err)
+		return ""
+	}
+	return source
+}
+
+func (c *Cache) writeImage(w http.ResponseWriter, r *http.Request, name string, modTime time.Time, data []byte) {
+	header := w.Header()
+	header.Set("content-type", "image/png")
+	// The path already changes when the row points at a different URL, so this
+	// only has to be short enough to pick up a re-fetch of the same URL.
+	header.Set("cache-control", "public, max-age=86400")
+	header.Set("x-content-type-options", "nosniff")
+	http.ServeContent(w, r, name, modTime, bytes.NewReader(data))
+}
+
+// writeMiss is the "there is no icon here" answer. It is cacheable for a
+// minute so a board full of sites without a usable favicon does not re-ask on
+// every render, and short enough that the first successful download shows up
+// promptly.
+func (c *Cache) writeMiss(w http.ResponseWriter) {
+	header := w.Header()
+	header.Set("content-type", "text/plain; charset=utf-8")
+	header.Set("cache-control", "public, max-age=60")
+	w.WriteHeader(http.StatusNotFound)
+	_, _ = io.WriteString(w, "no favicon\n")
+}
+
+// stored reports whether the file exists and whether it is still fresh.
+func (c *Cache) stored(name string) (fresh bool, exists bool) {
+	info, err := os.Stat(filepath.Join(c.dir, name))
+	if err != nil || info.IsDir() {
+		return false, false
+	}
+	return time.Since(info.ModTime()) <= c.ttl, true
+}
+
+func (c *Cache) read(name string) ([]byte, time.Time, error) {
+	path := filepath.Join(c.dir, name)
+	info, err := os.Stat(path)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	if len(data) == 0 {
+		return nil, time.Time{}, errors.New("stored favicon is empty")
+	}
+	return data, info.ModTime(), nil
+}
+
+func (c *Cache) coolingOff(name string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	until, failed := c.failed[name]
+	return failed && time.Now().Before(until)
+}
+
+// fetchOnce downloads, normalizes and stores one icon, collapsing concurrent
+// callers onto a single request and remembering a failure for a cooldown.
+func (c *Cache) fetchOnce(ctx context.Context, name, source string) ([]byte, error) {
+	c.mu.Lock()
+	if until, failed := c.failed[name]; failed && time.Now().Before(until) {
+		c.mu.Unlock()
+		return nil, errCoolingOff
+	}
+	if existing, running := c.inflight[name]; running {
+		c.mu.Unlock()
+		select {
+		case <-existing.done:
+			return existing.data, existing.err
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	current := &download{done: make(chan struct{})}
+	c.inflight[name] = current
+	c.mu.Unlock()
+
+	// The download outlives the request that started it. A viewer who navigates
+	// away mid-fetch must not cancel the icon out from under the next one.
+	fetchCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), fetchTimeout)
+	defer cancel()
+
+	current.data, current.err = c.storeIcon(fetchCtx, name, source)
+	close(current.done)
+
+	c.mu.Lock()
+	delete(c.inflight, name)
+	if current.err != nil {
+		if len(c.failed) > maxFailureEntries {
+			c.failed = map[string]time.Time{}
+		}
+		c.failed[name] = time.Now().Add(failureCooldown)
+	} else {
+		delete(c.failed, name)
+	}
+	c.mu.Unlock()
+
+	return current.data, current.err
+}
+
+func (c *Cache) storeIcon(ctx context.Context, name, source string) ([]byte, error) {
+	raw, err := c.fetch(ctx, source)
+	if err != nil {
+		return nil, err
+	}
+	normalized, err := Normalize(raw)
+	if err != nil {
+		return nil, fmt.Errorf("normalize %s: %w", source, err)
+	}
+	if err := c.write(name, normalized); err != nil {
+		return nil, err
+	}
+	c.logger.Info("favicon stored", "file", name, "source", source,
+		"sourceBytes", len(raw), "bytes", len(normalized))
+	return normalized, nil
+}
+
+func (c *Cache) fetch(ctx context.Context, source string) ([]byte, error) {
+	if !fetchable(source) {
+		return nil, fmt.Errorf("%w: %q", ErrUnfetchableURL, source)
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, source, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %q", ErrUnfetchableURL, source)
+	}
+	request.Header.Set("user-agent", userAgent)
+	request.Header.Set("accept", "image/png,image/x-icon,image/*;q=0.8,*/*;q=0.5")
+
+	response, err := c.client.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", source, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("fetch %s: upstream answered %d", source, response.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(response.Body, maxDownloadBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", source, err)
+	}
+	if len(body) > maxDownloadBytes {
+		return nil, fmt.Errorf("fetch %s: larger than %d bytes", source, maxDownloadBytes)
+	}
+	if len(body) == 0 {
+		return nil, fmt.Errorf("fetch %s: upstream served an empty body", source)
+	}
+	return body, nil
+}
+
+// write replaces the file through a temporary in the same directory, so a
+// request never reads a half-written PNG, and then drops the icons this site
+// stored under an older source URL.
+func (c *Cache) write(name string, data []byte) error {
+	path := filepath.Join(c.dir, name)
+	temp, err := os.CreateTemp(c.dir, ".favicon-*")
+	if err != nil {
+		return fmt.Errorf("create favicon file: %w", err)
+	}
+	tempName := temp.Name()
+	defer os.Remove(tempName)
+
+	if err := temp.Chmod(0o644); err != nil {
+		temp.Close()
+		return fmt.Errorf("chmod favicon file: %w", err)
+	}
+	if _, err := temp.Write(data); err != nil {
+		temp.Close()
+		return fmt.Errorf("write favicon file: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close favicon file: %w", err)
+	}
+	if err := os.Rename(tempName, path); err != nil {
+		return fmt.Errorf("store favicon file: %w", err)
+	}
+	c.pruneSuperseded(name)
+	return nil
+}
+
+func (c *Cache) pruneSuperseded(name string) {
+	host, ok := parseName(name)
+	if !ok {
+		return
+	}
+	matches, err := filepath.Glob(filepath.Join(c.dir, host+"-*.png"))
+	if err != nil {
+		return
+	}
+	for _, match := range matches {
+		if filepath.Base(match) != name {
+			_ = os.Remove(match)
+		}
+	}
+}
+
+// fileName is `<host>-<digest of the source URL>.png`. Putting the digest in
+// the name is what makes a changed favicon URL a changed path: no metadata
+// sidecar to keep in sync, and a board render that predates the change simply
+// asks for a file that is no longer the current one.
+func fileName(host, sourceURL string) string {
+	cleaned := strings.ToLower(strings.TrimSpace(host))
+	if len(cleaned) > 253 || !hostPattern.MatchString(cleaned) {
+		return ""
+	}
+	if !fetchable(sourceURL) {
+		return ""
+	}
+	return cleaned + "-" + digest(sourceURL) + ".png"
+}
+
+// parseName reads a requested file name back, and is the only thing standing
+// between a request path and a filesystem path: a name that does not split
+// into a valid hostname plus a hex digest is refused outright, so no request
+// can name a file outside the cache directory.
+func parseName(name string) (string, bool) {
+	stem, isPNG := strings.CutSuffix(name, ".png")
+	if !isPNG {
+		return "", false
+	}
+	cut := strings.LastIndex(stem, "-")
+	if cut <= 0 {
+		return "", false
+	}
+	host, fingerprint := stem[:cut], stem[cut+1:]
+	if len(fingerprint) != digestLength || !digestPattern.MatchString(fingerprint) {
+		return "", false
+	}
+	if len(host) > 253 || !hostPattern.MatchString(host) {
+		return "", false
+	}
+	return host, true
+}
+
+func digest(sourceURL string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(sourceURL)))
+	return hex.EncodeToString(sum[:])[:digestLength]
+}
+
+// fetchable is the scheme allowlist. A stored value could be anything a
+// submitter sent, and only an absolute http(s) URL is ever requested.
+func fetchable(sourceURL string) bool {
+	trimmed := strings.TrimSpace(sourceURL)
+	if trimmed == "" || len(trimmed) > 2000 {
+		return false
+	}
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return false
+	}
+	scheme := strings.ToLower(parsed.Scheme)
+	return (scheme == "http" || scheme == "https") && parsed.Hostname() != ""
+}
+
+// newClient is the downloader.
+//
+// The URL comes from a public write endpoint, so the dialer refuses to connect
+// to anything that is not a public address: without that check, POST
+// /api/submit-site with `favicon: "http://169.254.169.254/…"` would make this
+// server read the metadata service on the submitter's behalf. The check runs on
+// the resolved address, which is what makes it survive a DNS name that points
+// at 127.0.0.1 and a redirect chain that ends there.
+func newClient(allowPrivateHosts bool) *http.Client {
+	dialer := &net.Dialer{Timeout: 5 * time.Second}
+	if !allowPrivateHosts {
+		dialer.Control = func(_, address string, _ syscall.RawConn) error {
+			host, _, err := net.SplitHostPort(address)
+			if err != nil {
+				return fmt.Errorf("refusing to fetch from %q", address)
+			}
+			ip := net.ParseIP(host)
+			if ip == nil || !publicIP(ip) {
+				return fmt.Errorf("refusing to fetch a favicon from the non-public address %s", host)
+			}
+			return nil
+		}
+	}
+	return &http.Client{
+		Timeout: fetchTimeout,
+		Transport: &http.Transport{
+			DialContext:         dialer.DialContext,
+			TLSHandshakeTimeout: 5 * time.Second,
+			DisableKeepAlives:   true,
+			MaxIdleConns:        4,
+		},
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= maxRedirects {
+				return fmt.Errorf("stopped after %d redirects", maxRedirects)
+			}
+			if !fetchable(req.URL.String()) {
+				return fmt.Errorf("%w: %q", ErrUnfetchableURL, req.URL.String())
+			}
+			return nil
+		},
+	}
+}
+
+// publicIP is the routable-internet test: everything private, local, or
+// otherwise addressed at the machine's own network is out.
+func publicIP(ip net.IP) bool {
+	if ip.IsLoopback() || ip.IsPrivate() || ip.IsUnspecified() ||
+		ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() ||
+		ip.IsInterfaceLocalMulticast() || ip.IsMulticast() {
+		return false
+	}
+	// Carrier-grade NAT (100.64.0.0/10), which IsPrivate does not cover.
+	if v4 := ip.To4(); v4 != nil && v4[0] == 100 && v4[1] >= 64 && v4[1] <= 127 {
+		return false
+	}
+	return true
+}

--- a/backend/internal/favicon/cache_test.go
+++ b/backend/internal/favicon/cache_test.go
@@ -1,0 +1,427 @@
+package favicon_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"makefaster/internal/favicon"
+)
+
+// upstream is the origin a favicon is downloaded from. Every test here serves
+// its own: nothing in this package is allowed to reach the real internet, and
+// counting the requests is how a cache hit is told apart from a re-download.
+type upstream struct {
+	server *httptest.Server
+	hits   atomic.Int64
+
+	mu      sync.Mutex
+	status  int
+	body    []byte
+	delay   time.Duration
+	headers map[string]string
+}
+
+func newUpstream(t *testing.T, body []byte) *upstream {
+	t.Helper()
+	up := &upstream{status: http.StatusOK, body: body}
+	up.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		up.hits.Add(1)
+		up.mu.Lock()
+		status, body, delay, headers := up.status, up.body, up.delay, up.headers
+		up.mu.Unlock()
+
+		time.Sleep(delay)
+		for key, value := range headers {
+			w.Header().Set(key, value)
+		}
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(up.server.Close)
+	return up
+}
+
+func (u *upstream) url() string { return u.server.URL + "/favicon.ico" }
+
+func (u *upstream) answer(status int, body []byte) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.status, u.body = status, body
+}
+
+func (u *upstream) slow(delay time.Duration) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	u.delay = delay
+}
+
+// newCache is a cache with a stub resolver: it answers with whatever URL the
+// test says the site's row is pointing at.
+//
+// AllowPrivateHosts is on because the stub upstream is on 127.0.0.1. Production
+// leaves it off, and TestTheDownloaderRefusesPrivateAddresses covers that.
+func newCache(t *testing.T, source func() string) (*favicon.Cache, string) {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), "favicons")
+	cache, err := favicon.New(favicon.Options{
+		Dir:               dir,
+		AllowPrivateHosts: true,
+		Resolver: func(context.Context, string) (string, error) {
+			return source(), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("new cache: %v", err)
+	}
+	return cache, cache.Dir()
+}
+
+func get(t *testing.T, cache *favicon.Cache, path string) *httptest.ResponseRecorder {
+	t.Helper()
+	recorder := httptest.NewRecorder()
+	cache.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, path, nil))
+	return recorder
+}
+
+// waitForFile gives a background download a moment to land, so a test can
+// assert on what Prime actually stored rather than on when it stored it.
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if info, err := os.Stat(path); err == nil && info.Size() > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("no file appeared at %s", path)
+}
+
+func storedPath(dir, servedPath string) string {
+	return filepath.Join(dir, strings.TrimPrefix(servedPath, favicon.URLPrefix))
+}
+
+// The page's <img src> is a path on this server, and it changes when the row
+// starts pointing at a different icon.
+func TestPathIsSameOriginAndChangesWithTheSource(t *testing.T) {
+	cache, _ := newCache(t, func() string { return "" })
+
+	path := cache.Path("example.com", "https://cdn.example.com/icon.png")
+	if !strings.HasPrefix(path, favicon.URLPrefix) {
+		t.Fatalf("path %q is not served by this origin", path)
+	}
+	if strings.Contains(path, "cdn.example.com") {
+		t.Fatalf("path %q leaks the third-party URL", path)
+	}
+	if other := cache.Path("example.com", "https://example.com/favicon.ico"); other == path {
+		t.Fatalf("two source URLs share the path %q", path)
+	}
+	if again := cache.Path("example.com", "https://cdn.example.com/icon.png"); again != path {
+		t.Fatalf("the same source gave %q then %q", path, again)
+	}
+}
+
+// A stored value this server will not fetch gets no path at all, so the board
+// falls back to the site's letter instead of hotlinking it.
+func TestPathIsEmptyForAnythingUnfetchable(t *testing.T) {
+	cache, _ := newCache(t, func() string { return "" })
+
+	cases := map[string]struct{ host, source string }{
+		"no favicon":         {"example.com", ""},
+		"a javascript url":   {"example.com", "javascript:alert(1)"},
+		"a data url":         {"example.com", "data:image/png;base64,iVBORw0K"},
+		"an ftp url":         {"example.com", "ftp://example.com/icon.png"},
+		"a relative path":    {"example.com", "/favicon.ico"},
+		"no host in the url": {"example.com", "https:///favicon.ico"},
+		"a bad site host":    {"../../etc", "https://example.com/favicon.ico"},
+		"a bare host":        {"localhost", "https://example.com/favicon.ico"},
+	}
+	for name, input := range cases {
+		if path := cache.Path(input.host, input.source); path != "" {
+			t.Fatalf("%s produced the path %q", name, path)
+		}
+	}
+}
+
+// The whole point: the icon is downloaded from its origin, converted to the one
+// size and format the board draws, and served from here.
+func TestServeDownloadsNormalizesAndThenHitsTheStoredFile(t *testing.T) {
+	up := newUpstream(t, solidPNG(t, 128, 128, blue))
+	cache, dir := newCache(t, up.url)
+
+	path := cache.Path("example.com", up.url())
+	response := get(t, cache, path)
+	if response.Code != http.StatusOK {
+		t.Fatalf("first GET %s answered %d", path, response.Code)
+	}
+	if contentType := response.Header().Get("content-type"); contentType != "image/png" {
+		t.Fatalf("content-type is %q, want image/png", contentType)
+	}
+	if cacheControl := response.Header().Get("cache-control"); !strings.Contains(cacheControl, "max-age=") {
+		t.Fatalf("cache-control is %q, want a max-age", cacheControl)
+	}
+	// Same origin as the board, so the browser needs no CORS grant to draw it.
+	if response.Header().Get("access-control-allow-origin") != "" {
+		t.Fatalf("the favicon route should not need to negotiate CORS")
+	}
+
+	image := decodePNG(t, response.Body.Bytes())
+	if image.Bounds().Dx() != favicon.Size || image.Bounds().Dy() != favicon.Size {
+		t.Fatalf("served a %dx%d icon, want %d square",
+			image.Bounds().Dx(), image.Bounds().Dy(), favicon.Size)
+	}
+	assertColor(t, image, 32, 32, blue)
+
+	stored, err := os.ReadFile(storedPath(dir, path))
+	if err != nil {
+		t.Fatalf("the normalized icon was not stored: %v", err)
+	}
+	if len(stored) != response.Body.Len() {
+		t.Fatalf("stored %d bytes but served %d", len(stored), response.Body.Len())
+	}
+
+	// The second request is a file read, not a second trip to somebody else's
+	// CDN.
+	second := get(t, cache, path)
+	if second.Code != http.StatusOK {
+		t.Fatalf("second GET answered %d", second.Code)
+	}
+	if hits := up.hits.Load(); hits != 1 {
+		t.Fatalf("the origin was asked %d times, want exactly once", hits)
+	}
+}
+
+// The failure this feature exists for: an origin that refuses the request. The
+// row keeps its letter, and the refusal is not retried on every render.
+func TestServeAnswers404WhenTheOriginRefuses(t *testing.T) {
+	up := newUpstream(t, nil)
+	up.answer(http.StatusForbidden, []byte("hotlinking is not allowed"))
+	cache, dir := newCache(t, up.url)
+
+	path := cache.Path("example.com", up.url())
+	if response := get(t, cache, path); response.Code != http.StatusNotFound {
+		t.Fatalf("GET %s answered %d, want 404", path, response.Code)
+	}
+	if _, err := os.Stat(storedPath(dir, path)); !os.IsNotExist(err) {
+		t.Fatalf("a refused download should store nothing (stat error: %v)", err)
+	}
+
+	for attempt := 0; attempt < 3; attempt++ {
+		if response := get(t, cache, path); response.Code != http.StatusNotFound {
+			t.Fatalf("retry %d answered %d, want 404", attempt, response.Code)
+		}
+	}
+	if hits := up.hits.Load(); hits != 1 {
+		t.Fatalf("the origin was asked %d times, want once until the cooldown expires", hits)
+	}
+}
+
+// An origin that answers 200 with something that is not an image — an HTML
+// error page, an SVG this cannot rasterize — is the same non-event.
+func TestServeAnswers404WhenTheOriginServesSomethingElse(t *testing.T) {
+	up := newUpstream(t, []byte("<!DOCTYPE html><title>Not found</title>"))
+	cache, dir := newCache(t, up.url)
+
+	path := cache.Path("example.com", up.url())
+	if response := get(t, cache, path); response.Code != http.StatusNotFound {
+		t.Fatalf("GET %s answered %d, want 404", path, response.Code)
+	}
+	if entries, err := os.ReadDir(dir); err != nil || len(entries) != 0 {
+		t.Fatalf("the cache directory holds %d entries (err %v), want none", len(entries), err)
+	}
+}
+
+// Nothing but a path this cache handed out is answered, which is also what
+// keeps a request from naming a file outside the cache directory.
+func TestServeRefusesAPathItDidNotHandOut(t *testing.T) {
+	up := newUpstream(t, solidPNG(t, 32, 32, red))
+	cache, _ := newCache(t, up.url)
+
+	current := cache.Path("example.com", up.url())
+	stale := cache.Path("example.com", "https://cdn.example.com/old-icon.png")
+
+	for _, path := range []string{
+		favicon.URLPrefix + "../../etc/passwd",
+		favicon.URLPrefix + "..%2f..%2fpasswd.png",
+		favicon.URLPrefix + "example.com.png",
+		favicon.URLPrefix + "example.com-nothex.png",
+		favicon.URLPrefix + "-0123456789.png",
+		favicon.URLPrefix + "example.com-0123456789.gif",
+		stale, // the row points somewhere else now
+	} {
+		if response := get(t, cache, path); response.Code != http.StatusNotFound {
+			t.Fatalf("GET %s answered %d, want 404", path, response.Code)
+		}
+	}
+	if hits := up.hits.Load(); hits != 0 {
+		t.Fatalf("the origin was asked %d times for paths this cache never issued", hits)
+	}
+	if response := get(t, cache, current); response.Code != http.StatusOK {
+		t.Fatalf("the current path answered %d, want 200", response.Code)
+	}
+}
+
+// Priming is what ingest and a board render do: start the download, wait for
+// nothing.
+func TestPrimeStoresInTheBackgroundWithoutBlocking(t *testing.T) {
+	up := newUpstream(t, solidPNG(t, 64, 64, red))
+	up.slow(150 * time.Millisecond)
+	cache, dir := newCache(t, up.url)
+
+	path := cache.Path("example.com", up.url())
+	started := time.Now()
+	cache.Prime("example.com", up.url())
+	if elapsed := time.Since(started); elapsed > 100*time.Millisecond {
+		t.Fatalf("Prime blocked for %s; it must not wait on the download", elapsed)
+	}
+
+	waitForFile(t, storedPath(dir, path))
+	if response := get(t, cache, path); response.Code != http.StatusOK {
+		t.Fatalf("GET %s answered %d after priming", path, response.Code)
+	}
+	if hits := up.hits.Load(); hits != 1 {
+		t.Fatalf("the origin was asked %d times, want once", hits)
+	}
+}
+
+// A stored file that is past its TTL is still served immediately; the refresh
+// happens behind the request.
+func TestServeReturnsAStaleFileAndRefreshesBehindIt(t *testing.T) {
+	up := newUpstream(t, solidPNG(t, 64, 64, red))
+	cache, dir := newCache(t, up.url)
+
+	path := cache.Path("example.com", up.url())
+	if response := get(t, cache, path); response.Code != http.StatusOK {
+		t.Fatalf("first GET answered %d", response.Code)
+	}
+
+	file := storedPath(dir, path)
+	stale := time.Now().Add(-30 * 24 * time.Hour)
+	if err := os.Chtimes(file, stale, stale); err != nil {
+		t.Fatalf("age the stored file: %v", err)
+	}
+
+	up.answer(http.StatusOK, solidPNG(t, 64, 64, blue))
+	response := get(t, cache, path)
+	if response.Code != http.StatusOK {
+		t.Fatalf("the stale GET answered %d, want the stored bytes", response.Code)
+	}
+	assertColor(t, decodePNG(t, response.Body.Bytes()), 32, 32, red)
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if info, err := os.Stat(file); err == nil && info.ModTime().After(stale.Add(time.Hour)) {
+			assertColor(t, decodePNG(t, mustRead(t, file)), 32, 32, blue)
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("the stale icon was never refreshed")
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return data
+}
+
+// A board render asks for every icon at once. One download per icon, however
+// many viewers arrive together.
+func TestConcurrentRequestsShareOneDownload(t *testing.T) {
+	up := newUpstream(t, solidPNG(t, 64, 64, blue))
+	up.slow(100 * time.Millisecond)
+	cache, _ := newCache(t, up.url)
+	path := cache.Path("example.com", up.url())
+
+	var group sync.WaitGroup
+	codes := make([]int, 8)
+	for index := range codes {
+		group.Add(1)
+		go func(slot int) {
+			defer group.Done()
+			codes[slot] = get(t, cache, path).Code
+		}(index)
+	}
+	group.Wait()
+
+	for slot, code := range codes {
+		if code != http.StatusOK {
+			t.Fatalf("viewer %d got %d, want 200", slot, code)
+		}
+	}
+	if hits := up.hits.Load(); hits != 1 {
+		t.Fatalf("the origin was asked %d times, want once for all eight viewers", hits)
+	}
+}
+
+// The favicon URL on a site row arrives through a public write endpoint, so the
+// downloader is the one place this server would happily fetch a URL a stranger
+// chose. It refuses anything that is not a public address.
+func TestTheDownloaderRefusesPrivateAddresses(t *testing.T) {
+	up := newUpstream(t, solidPNG(t, 64, 64, red))
+	dir := filepath.Join(t.TempDir(), "favicons")
+	cache, err := favicon.New(favicon.Options{
+		Dir: dir,
+		Resolver: func(context.Context, string) (string, error) {
+			return up.url(), nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("new cache: %v", err)
+	}
+
+	path := cache.Path("example.com", up.url())
+	if response := get(t, cache, path); response.Code != http.StatusNotFound {
+		t.Fatalf("GET %s answered %d, want 404 for a loopback origin", path, response.Code)
+	}
+	if hits := up.hits.Load(); hits != 0 {
+		t.Fatalf("the loopback origin was reached %d times", hits)
+	}
+}
+
+// A deployment with nowhere to write serves no icons rather than falling back
+// to hotlinking.
+func TestNewRefusesWithoutADirectory(t *testing.T) {
+	for _, dir := range []string{"", "   "} {
+		if _, err := favicon.New(favicon.Options{Dir: dir}); err == nil {
+			t.Fatalf("New(%q) should have refused", dir)
+		}
+	}
+}
+
+// A file stored under an older source URL is dropped when the new one lands, so
+// a rebranded site does not leave its old icon behind forever.
+func TestStoringSupersedesTheSitesEarlierIcon(t *testing.T) {
+	up := newUpstream(t, solidPNG(t, 64, 64, red))
+	source := up.url()
+	cache, dir := newCache(t, func() string { return source })
+
+	first := cache.Path("example.com", source)
+	if response := get(t, cache, first); response.Code != http.StatusOK {
+		t.Fatalf("first GET answered %d", response.Code)
+	}
+
+	source = up.server.URL + "/new-icon.png"
+	second := cache.Path("example.com", source)
+	if response := get(t, cache, second); response.Code != http.StatusOK {
+		t.Fatalf("GET the new icon answered %d", response.Code)
+	}
+
+	if _, err := os.Stat(storedPath(dir, first)); !os.IsNotExist(err) {
+		t.Fatalf("the superseded icon is still stored (stat error: %v)", err)
+	}
+	if _, err := os.Stat(storedPath(dir, second)); err != nil {
+		t.Fatalf("the current icon is not stored: %v", err)
+	}
+}

--- a/backend/internal/favicon/ico.go
+++ b/backend/internal/favicon/ico.go
@@ -1,0 +1,330 @@
+package favicon
+
+// ICO is the format most of the web still answers /favicon.ico with, and the
+// standard library has no decoder for it. It is a container: a directory of
+// entries, each holding either a whole PNG or a bare Windows DIB (a BMP with no
+// file header, stored upside down, with a 1-bit transparency mask stapled
+// underneath the colour rows).
+//
+// This decodes the subset that favicons are actually written in — PNG payloads
+// and uncompressed 1/4/8/24/32-bit DIBs — and refuses the rest rather than
+// guessing. A refusal costs a row its icon, not its render: the board falls
+// back to the site's initial.
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"sort"
+)
+
+// The DIB compression schemes worth accepting: uncompressed, and the
+// "bitfields" variant that 32-bit icons are sometimes tagged with while still
+// being plain BGRA. Run-length encoded bitmaps are refused.
+const (
+	compressionRGB       = 0
+	compressionBitfields = 3
+)
+
+const (
+	icoHeaderBytes = 6
+	icoEntryBytes  = 16
+	dibHeaderMin   = 40
+)
+
+var pngMagic = []byte{0x89, 'P', 'N', 'G', '\r', '\n', 0x1a, '\n'}
+
+// looksLikeICO sniffs the container header: two reserved zero bytes, then type
+// 1 (icon) or 2 (cursor), then a non-zero entry count.
+func looksLikeICO(raw []byte) bool {
+	if len(raw) < icoHeaderBytes {
+		return false
+	}
+	if raw[0] != 0 || raw[1] != 0 || raw[3] != 0 {
+		return false
+	}
+	if raw[2] != 1 && raw[2] != 2 {
+		return false
+	}
+	return le16(raw, 4) > 0
+}
+
+func looksLikeBMP(raw []byte) bool {
+	return len(raw) >= 14+dibHeaderMin && raw[0] == 'B' && raw[1] == 'M'
+}
+
+// icoEntry is one directory record: the declared dimensions plus where the
+// payload lives.
+type icoEntry struct {
+	width  int
+	height int
+	bpp    int
+	offset int
+	length int
+}
+
+// decodeICO picks the best entry the file offers and decodes it, falling
+// through to the next one when a payload turns out to be a variant this does
+// not read.
+func decodeICO(raw []byte) (image.Image, error) {
+	count := int(le16(raw, 4))
+	if len(raw) < icoHeaderBytes+count*icoEntryBytes {
+		return nil, fmt.Errorf("%w: ico directory is truncated", ErrUnsupportedImage)
+	}
+
+	entries := make([]icoEntry, 0, count)
+	for index := 0; index < count; index++ {
+		at := icoHeaderBytes + index*icoEntryBytes
+		entry := icoEntry{
+			width:  icoEdge(raw[at]),
+			height: icoEdge(raw[at+1]),
+			bpp:    int(le16(raw, at+6)),
+			length: int(le32(raw, at+8)),
+			offset: int(le32(raw, at+12)),
+		}
+		if entry.offset <= 0 || entry.length <= 0 || entry.offset+entry.length > len(raw) {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	if len(entries) == 0 {
+		return nil, fmt.Errorf("%w: ico has no usable entries", ErrUnsupportedImage)
+	}
+
+	sort.SliceStable(entries, func(a, b int) bool { return entryScore(entries[a]) > entryScore(entries[b]) })
+
+	var lastErr error
+	for _, entry := range entries {
+		payload := raw[entry.offset : entry.offset+entry.length]
+		decoded, err := decodeICOPayload(payload)
+		if err == nil {
+			return decoded, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}
+
+// entryScore ranks the directory. The smallest entry that is still at least
+// Size wins, because it needs the least resampling to land on the served size;
+// below that, bigger is better, and depth breaks ties between equal edges.
+func entryScore(entry icoEntry) int {
+	edge := entry.width
+	if entry.height > edge {
+		edge = entry.height
+	}
+	if edge >= Size {
+		return 1_000_000 - edge*100 + entry.bpp
+	}
+	return edge*100 + entry.bpp
+}
+
+// icoEdge reads a directory dimension, where zero is the format's way of
+// spelling 256.
+func icoEdge(value byte) int {
+	if value == 0 {
+		return 256
+	}
+	return int(value)
+}
+
+func decodeICOPayload(payload []byte) (image.Image, error) {
+	if bytes.HasPrefix(payload, pngMagic) {
+		decoded, err := png.Decode(bytes.NewReader(payload))
+		if err != nil {
+			return nil, fmt.Errorf("%w: ico png payload: %v", ErrUnsupportedImage, err)
+		}
+		return decoded, nil
+	}
+	if len(payload) < dibHeaderMin {
+		return nil, fmt.Errorf("%w: ico payload is too short to be a dib", ErrUnsupportedImage)
+	}
+	return decodeDIB(payload, true, -1)
+}
+
+// decodeBMP reads a standalone .bmp — the same DIB with a 14-byte file header
+// in front of it and no transparency mask underneath.
+func decodeBMP(raw []byte) (image.Image, error) {
+	pixelOffset := int(le32(raw, 10))
+	if pixelOffset <= 0 || pixelOffset >= len(raw) {
+		pixelOffset = -1
+	} else {
+		pixelOffset -= 14
+	}
+	return decodeDIB(raw[14:], false, pixelOffset)
+}
+
+// decodeDIB decodes an uncompressed device-independent bitmap.
+//
+// iconMask says the header's height covers the colour rows *plus* a 1-bit AND
+// mask below them, which is how ICO stores transparency for every depth that
+// has no alpha channel of its own. pixelOffset is where the colour rows start
+// relative to the DIB, or -1 for "straight after the header and palette", which
+// is how ICO packs them.
+func decodeDIB(data []byte, iconMask bool, pixelOffset int) (image.Image, error) {
+	headerSize := int(le32(data, 0))
+	if headerSize < dibHeaderMin || headerSize > len(data) {
+		return nil, fmt.Errorf("%w: dib header size %d", ErrUnsupportedImage, headerSize)
+	}
+
+	width := int(int32(le32(data, 4)))
+	height := int(int32(le32(data, 8)))
+	bpp := int(le16(data, 14))
+	compression := int(le32(data, 16))
+	paletteCount := int(le32(data, 32))
+
+	// A negative height means the rows are stored top-down, which only ever
+	// happens in standalone BMPs.
+	topDown := height < 0
+	if topDown {
+		height = -height
+	}
+	if iconMask {
+		height /= 2
+	}
+	if width <= 0 || height <= 0 || width > maxSourceEdge || height > maxSourceEdge {
+		return nil, fmt.Errorf("%w: dib is %dx%d", ErrUnsupportedImage, width, height)
+	}
+	if compression != compressionRGB && !(compression == compressionBitfields && bpp == 32) {
+		return nil, fmt.Errorf("%w: dib compression %d at %d bpp", ErrUnsupportedImage, compression, bpp)
+	}
+
+	palette, paletteBytes, err := readPalette(data, headerSize, bpp, paletteCount, compression)
+	if err != nil {
+		return nil, err
+	}
+	if pixelOffset < 0 {
+		pixelOffset = headerSize + paletteBytes
+	}
+
+	stride := ((width*bpp + 31) / 32) * 4
+	if stride <= 0 || pixelOffset < 0 || pixelOffset+stride*height > len(data) {
+		return nil, fmt.Errorf("%w: dib pixel data is truncated", ErrUnsupportedImage)
+	}
+
+	decoded, allAlphaZero := readDIBPixels(data[pixelOffset:], width, height, bpp, stride, topDown, palette)
+
+	// A 32-bit icon whose alpha channel is entirely zero is not invisible, it
+	// is an icon written before alpha was standard: those rely on the AND mask
+	// exactly like the shallower depths do.
+	if bpp == 32 && allAlphaZero {
+		fillOpaque(decoded)
+	}
+	if iconMask && (bpp != 32 || allAlphaZero) {
+		applyANDMask(decoded, data, pixelOffset+stride*height, width, height, topDown)
+	}
+	return decoded, nil
+}
+
+func readPalette(data []byte, headerSize, bpp, declared, compression int) ([]color.NRGBA, int, error) {
+	// The three channel masks a BI_BITFIELDS header carries sit where a
+	// palette would, and 32-bit icons have no palette to read.
+	if bpp > 8 {
+		if compression == compressionBitfields {
+			return nil, 12, nil
+		}
+		return nil, 0, nil
+	}
+	count := declared
+	if count <= 0 || count > 1<<bpp {
+		count = 1 << bpp
+	}
+	size := count * 4
+	if headerSize+size > len(data) {
+		return nil, 0, fmt.Errorf("%w: dib palette is truncated", ErrUnsupportedImage)
+	}
+	palette := make([]color.NRGBA, count)
+	for index := 0; index < count; index++ {
+		at := headerSize + index*4
+		palette[index] = color.NRGBA{R: data[at+2], G: data[at+1], B: data[at], A: 0xff}
+	}
+	return palette, size, nil
+}
+
+// readDIBPixels reads the colour rows. The second return reports that every
+// alpha byte was zero, which only means anything at 32 bpp.
+func readDIBPixels(pixels []byte, width, height, bpp, stride int, topDown bool, palette []color.NRGBA) (*image.NRGBA, bool) {
+	out := image.NewNRGBA(image.Rect(0, 0, width, height))
+	allAlphaZero := true
+
+	for row := 0; row < height; row++ {
+		y := height - 1 - row
+		if topDown {
+			y = row
+		}
+		line := pixels[row*stride : row*stride+stride]
+		for x := 0; x < width; x++ {
+			pixel := dibPixel(line, x, bpp, palette)
+			if pixel.A != 0 {
+				allAlphaZero = false
+			}
+			out.SetNRGBA(x, y, pixel)
+		}
+	}
+	return out, allAlphaZero
+}
+
+func dibPixel(line []byte, x, bpp int, palette []color.NRGBA) color.NRGBA {
+	switch bpp {
+	case 32:
+		at := x * 4
+		return color.NRGBA{R: line[at+2], G: line[at+1], B: line[at], A: line[at+3]}
+	case 24:
+		at := x * 3
+		return color.NRGBA{R: line[at+2], G: line[at+1], B: line[at], A: 0xff}
+	case 8:
+		return paletteAt(palette, int(line[x]))
+	case 4:
+		nibble := line[x/2]
+		if x%2 == 0 {
+			return paletteAt(palette, int(nibble>>4))
+		}
+		return paletteAt(palette, int(nibble&0x0f))
+	case 1:
+		bit := line[x/8] >> (7 - uint(x%8)) & 1
+		return paletteAt(palette, int(bit))
+	}
+	return color.NRGBA{}
+}
+
+func paletteAt(palette []color.NRGBA, index int) color.NRGBA {
+	if index < 0 || index >= len(palette) {
+		return color.NRGBA{}
+	}
+	return palette[index]
+}
+
+func fillOpaque(target *image.NRGBA) {
+	for offset := 3; offset < len(target.Pix); offset += 4 {
+		target.Pix[offset] = 0xff
+	}
+}
+
+// applyANDMask clears the pixels the icon's 1-bit mask marks transparent. A
+// truncated or missing mask leaves the icon opaque, which is a better answer
+// than refusing an icon that decoded fine.
+func applyANDMask(target *image.NRGBA, data []byte, start, width, height int, topDown bool) {
+	stride := ((width + 31) / 32) * 4
+	if start < 0 || start+stride*height > len(data) {
+		return
+	}
+	mask := data[start:]
+	for row := 0; row < height; row++ {
+		y := height - 1 - row
+		if topDown {
+			y = row
+		}
+		line := mask[row*stride : row*stride+stride]
+		for x := 0; x < width; x++ {
+			if line[x/8]>>(7-uint(x%8))&1 == 1 {
+				target.SetNRGBA(x, y, color.NRGBA{})
+			}
+		}
+	}
+}
+
+func le16(data []byte, at int) uint16 { return binary.LittleEndian.Uint16(data[at : at+2]) }
+func le32(data []byte, at int) uint32 { return binary.LittleEndian.Uint32(data[at : at+4]) }

--- a/backend/internal/favicon/normalize.go
+++ b/backend/internal/favicon/normalize.go
@@ -1,0 +1,176 @@
+package favicon
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"image"
+	"image/color"
+	"image/png"
+	"math"
+
+	// The formats a favicon actually arrives in. ICO and the bare DIBs inside
+	// it are decoded by ico.go, because the standard library has no decoder
+	// for the container every /favicon.ico in the wild still uses.
+	_ "image/gif"
+	_ "image/jpeg"
+	_ "image/png"
+)
+
+// Size is the edge of the square every icon is normalized to, in pixels.
+//
+// The board draws it into a 28px `.favicon-box` at 26px (css/style.css), so 64
+// is the next power of two that still has pixels to spare on a 2x display and
+// costs a couple of kilobytes. Everything the server stores is exactly this
+// size in exactly one format, so the page never has to care what the origin
+// served.
+const Size = 64
+
+// maxSourceEdge rejects an image nobody would use as a favicon before it is
+// resampled. A 1 MB body can still decode to something enormous, and this is
+// the cheap wall in front of that.
+const maxSourceEdge = 4096
+
+// ErrUnsupportedImage means the bytes were fetched fine and are not an image
+// this server can turn into a PNG — an SVG favicon, a WebP, or an HTML error
+// page served with a 200. The row keeps its letter fallback.
+var ErrUnsupportedImage = errors.New("not an image this server can normalize")
+
+// Normalize turns whatever an origin served into the one shape this server
+// publishes: a Size x Size PNG, the icon scaled to fit and centred on
+// transparency so a wide or tall source is not distorted.
+func Normalize(raw []byte) ([]byte, error) {
+	source, err := decode(raw)
+	if err != nil {
+		return nil, err
+	}
+	bounds := source.Bounds()
+	if bounds.Dx() <= 0 || bounds.Dy() <= 0 {
+		return nil, fmt.Errorf("%w: zero-sized image", ErrUnsupportedImage)
+	}
+	if bounds.Dx() > maxSourceEdge || bounds.Dy() > maxSourceEdge {
+		return nil, fmt.Errorf("%w: %dx%d is larger than %d px", ErrUnsupportedImage,
+			bounds.Dx(), bounds.Dy(), maxSourceEdge)
+	}
+
+	var out bytes.Buffer
+	encoder := png.Encoder{CompressionLevel: png.BestCompression}
+	if err := encoder.Encode(&out, fitSquare(source, Size)); err != nil {
+		return nil, fmt.Errorf("encode png: %w", err)
+	}
+	return out.Bytes(), nil
+}
+
+// decode reads the image formats a favicon URL answers with. ICO is sniffed
+// rather than registered, because its header (two zero bytes then a type) is
+// too weak a signature to hand to image.RegisterFormat.
+func decode(raw []byte) (image.Image, error) {
+	if looksLikeICO(raw) {
+		return decodeICO(raw)
+	}
+	if looksLikeBMP(raw) {
+		return decodeBMP(raw)
+	}
+	decoded, _, err := image.Decode(bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrUnsupportedImage, err)
+	}
+	return decoded, nil
+}
+
+// fitSquare scales src to fit a size x size canvas, keeping its aspect ratio
+// and centring what is left over.
+//
+// Downscaling averages every source pixel that falls inside a destination
+// pixel, which is what keeps a 256px icon from turning into aliased confetti at
+// 64px. Upscaling lands on nearest-neighbour, and that is the right answer for
+// the 16px icons this mostly sees: a 4x nearest scale stays crisp where a
+// smooth filter would only add blur.
+func fitSquare(src image.Image, size int) *image.NRGBA {
+	bounds := src.Bounds()
+	scale := math.Min(float64(size)/float64(bounds.Dx()), float64(size)/float64(bounds.Dy()))
+	width := clampEdge(int(math.Round(float64(bounds.Dx())*scale)), size)
+	height := clampEdge(int(math.Round(float64(bounds.Dy())*scale)), size)
+
+	dst := image.NewNRGBA(image.Rect(0, 0, size, size))
+	offsetX, offsetY := (size-width)/2, (size-height)/2
+	stepX := float64(bounds.Dx()) / float64(width)
+	stepY := float64(bounds.Dy()) / float64(height)
+
+	for y := 0; y < height; y++ {
+		y0, y1 := sourceSpan(bounds.Min.Y, bounds.Max.Y, y, stepY)
+		for x := 0; x < width; x++ {
+			x0, x1 := sourceSpan(bounds.Min.X, bounds.Max.X, x, stepX)
+			dst.SetNRGBA(offsetX+x, offsetY+y, averageArea(src, x0, x1, y0, y1))
+		}
+	}
+	return dst
+}
+
+// sourceSpan is the half-open source range a destination pixel covers, always
+// at least one pixel wide so an upscale samples rather than averaging nothing.
+func sourceSpan(min, max, index int, step float64) (int, int) {
+	start := min + int(float64(index)*step)
+	end := min + int(math.Ceil(float64(index+1)*step))
+	if end <= start {
+		end = start + 1
+	}
+	if start >= max {
+		start = max - 1
+	}
+	if end > max {
+		end = max
+	}
+	return start, end
+}
+
+// averageArea averages a rectangle of source pixels.
+//
+// The average is taken in alpha-premultiplied space — which is what
+// color.Color#RGBA already hands over — because averaging straight colour
+// alongside alpha is how a transparent icon picks up a dark halo. The result is
+// un-premultiplied once, at the end.
+func averageArea(src image.Image, x0, x1, y0, y1 int) color.NRGBA {
+	var sumR, sumG, sumB, sumA uint64
+	count := uint64((x1 - x0) * (y1 - y0))
+	if count == 0 {
+		return color.NRGBA{}
+	}
+	for y := y0; y < y1; y++ {
+		for x := x0; x < x1; x++ {
+			r, g, b, a := src.At(x, y).RGBA()
+			sumR += uint64(r)
+			sumG += uint64(g)
+			sumB += uint64(b)
+			sumA += uint64(a)
+		}
+	}
+	alpha := sumA / count
+	if alpha == 0 {
+		return color.NRGBA{}
+	}
+	return color.NRGBA{
+		R: unpremultiply(sumR/count, alpha),
+		G: unpremultiply(sumG/count, alpha),
+		B: unpremultiply(sumB/count, alpha),
+		A: uint8(alpha >> 8),
+	}
+}
+
+func unpremultiply(channel, alpha uint64) uint8 {
+	value := channel * 0xffff / alpha
+	if value > 0xffff {
+		value = 0xffff
+	}
+	return uint8(value >> 8)
+}
+
+func clampEdge(value, max int) int {
+	if value < 1 {
+		return 1
+	}
+	if value > max {
+		return max
+	}
+	return value
+}

--- a/backend/internal/favicon/normalize_test.go
+++ b/backend/internal/favicon/normalize_test.go
@@ -1,0 +1,239 @@
+package favicon_test
+
+import (
+	"bytes"
+	"encoding/binary"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
+	"testing"
+
+	"makefaster/internal/favicon"
+)
+
+// solidPNG is a source icon: one colour, whatever size an origin felt like
+// serving.
+func solidPNG(t *testing.T, width, height int, fill color.NRGBA) []byte {
+	t.Helper()
+	img := image.NewNRGBA(image.Rect(0, 0, width, height))
+	draw.Draw(img, img.Bounds(), &image.Uniform{fill}, image.Point{}, draw.Src)
+	var out bytes.Buffer
+	if err := png.Encode(&out, img); err != nil {
+		t.Fatalf("encode source png: %v", err)
+	}
+	return out.Bytes()
+}
+
+func decodePNG(t *testing.T, raw []byte) image.Image {
+	t.Helper()
+	decoded, err := png.Decode(bytes.NewReader(raw))
+	if err != nil {
+		t.Fatalf("the normalized bytes are not a png: %v", err)
+	}
+	return decoded
+}
+
+func assertColor(t *testing.T, img image.Image, x, y int, want color.NRGBA) {
+	t.Helper()
+	r, g, b, a := img.At(x, y).RGBA()
+	got := color.NRGBA{R: uint8(r >> 8), G: uint8(g >> 8), B: uint8(b >> 8), A: uint8(a >> 8)}
+	if got != want {
+		t.Fatalf("pixel (%d,%d) is %+v, want %+v", x, y, got, want)
+	}
+}
+
+var (
+	red   = color.NRGBA{R: 0xff, A: 0xff}
+	blue  = color.NRGBA{B: 0xff, A: 0xff}
+	clear = color.NRGBA{}
+)
+
+// Whatever arrives, exactly one size and one format leaves: the page's
+// `.favicon-box` is a fixed square and never has to reason about the original.
+func TestNormalizeAlwaysProducesOneSizeAndFormat(t *testing.T) {
+	for _, size := range []int{16, 32, 64, 128, 256} {
+		normalized, err := favicon.Normalize(solidPNG(t, size, size, red))
+		if err != nil {
+			t.Fatalf("normalize a %dpx icon: %v", size, err)
+		}
+		bounds := decodePNG(t, normalized).Bounds()
+		if bounds.Dx() != favicon.Size || bounds.Dy() != favicon.Size {
+			t.Fatalf("a %dpx icon normalized to %dx%d, want %d square",
+				size, bounds.Dx(), bounds.Dy(), favicon.Size)
+		}
+	}
+}
+
+func TestNormalizeAveragesADownscale(t *testing.T) {
+	source := image.NewNRGBA(image.Rect(0, 0, 128, 128))
+	draw.Draw(source, image.Rect(0, 0, 64, 128), &image.Uniform{red}, image.Point{}, draw.Src)
+	draw.Draw(source, image.Rect(64, 0, 128, 128), &image.Uniform{blue}, image.Point{}, draw.Src)
+	var encoded bytes.Buffer
+	if err := png.Encode(&encoded, source); err != nil {
+		t.Fatalf("encode source: %v", err)
+	}
+
+	normalized, err := favicon.Normalize(encoded.Bytes())
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	out := decodePNG(t, normalized)
+	assertColor(t, out, 8, 32, red)
+	assertColor(t, out, 56, 32, blue)
+}
+
+// A wide or tall icon is fitted, not stretched: the leftover is transparent, so
+// the board draws the original proportions inside its square box.
+func TestNormalizeFitsAndCentresANonSquareIcon(t *testing.T) {
+	normalized, err := favicon.Normalize(solidPNG(t, 64, 32, red))
+	if err != nil {
+		t.Fatalf("normalize: %v", err)
+	}
+	out := decodePNG(t, normalized)
+	assertColor(t, out, 32, 32, red)
+	assertColor(t, out, 32, 2, clear)
+	assertColor(t, out, 32, 61, clear)
+}
+
+// A JPEG or GIF favicon is as valid as a PNG one, and comes out as the same
+// PNG either way.
+func TestNormalizeReadsTheOtherStandardFormats(t *testing.T) {
+	gif := []byte{
+		'G', 'I', 'F', '8', '9', 'a', 0x01, 0x00, 0x01, 0x00, 0x80, 0x00, 0x00,
+		0xff, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x2c, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+		0x02, 0x02, 0x44, 0x01, 0x00, 0x3b,
+	}
+	normalized, err := favicon.Normalize(gif)
+	if err != nil {
+		t.Fatalf("normalize a gif: %v", err)
+	}
+	assertColor(t, decodePNG(t, normalized), 32, 32, red)
+}
+
+// The formats this server cannot rasterize — an SVG favicon, a WebP — and the
+// HTML error page an origin serves with a 200 all land here. The caller turns
+// that into the board's letter fallback rather than a broken image.
+func TestNormalizeRefusesWhatItCannotRead(t *testing.T) {
+	cases := map[string][]byte{
+		"an svg favicon":  []byte(`<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"/>`),
+		"an html page":    []byte("<!DOCTYPE html><title>404</title>"),
+		"empty bytes":     {},
+		"a truncated png": solidPNG(t, 16, 16, red)[:20],
+	}
+	for name, raw := range cases {
+		if _, err := favicon.Normalize(raw); err == nil {
+			t.Fatalf("normalizing %s should have failed", name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------- ICO
+
+// icoWithPayload wraps one payload in an ICO directory, which is how a real
+// /favicon.ico is put together.
+func icoWithPayload(width, height, bpp int, payload []byte) []byte {
+	out := make([]byte, 0, 22+len(payload))
+	out = append(out, 0, 0, 1, 0, 1, 0) // reserved, type 1 (icon), one entry
+	out = append(out, byte(width%256), byte(height%256), 0, 0)
+	out = binary.LittleEndian.AppendUint16(out, 1)
+	out = binary.LittleEndian.AppendUint16(out, uint16(bpp))
+	out = binary.LittleEndian.AppendUint32(out, uint32(len(payload)))
+	out = binary.LittleEndian.AppendUint32(out, 22)
+	return append(out, payload...)
+}
+
+// dibPayload is the other thing an ICO entry can hold: a headerless BMP, stored
+// bottom-up, with its declared height covering the colour rows plus a 1-bit
+// transparency mask underneath.
+func dibPayload(edge int, fill color.NRGBA) []byte {
+	header := make([]byte, 0, 40)
+	header = binary.LittleEndian.AppendUint32(header, 40)
+	header = binary.LittleEndian.AppendUint32(header, uint32(edge))
+	header = binary.LittleEndian.AppendUint32(header, uint32(edge*2))
+	header = binary.LittleEndian.AppendUint16(header, 1)
+	header = binary.LittleEndian.AppendUint16(header, 32)
+	header = append(header, make([]byte, 24)...) // compression 0 and the sizes nobody reads
+
+	pixels := make([]byte, 0, edge*edge*4)
+	for row := 0; row < edge; row++ {
+		for column := 0; column < edge; column++ {
+			pixels = append(pixels, fill.B, fill.G, fill.R, fill.A)
+		}
+	}
+	mask := make([]byte, ((edge+31)/32)*4*edge)
+	return append(append(header, pixels...), mask...)
+}
+
+func TestNormalizeReadsAnICOWithAPNGPayload(t *testing.T) {
+	normalized, err := favicon.Normalize(icoWithPayload(32, 32, 32, solidPNG(t, 32, 32, blue)))
+	if err != nil {
+		t.Fatalf("normalize an ico: %v", err)
+	}
+	out := decodePNG(t, normalized)
+	if out.Bounds().Dx() != favicon.Size {
+		t.Fatalf("normalized to %d px, want %d", out.Bounds().Dx(), favicon.Size)
+	}
+	assertColor(t, out, 32, 32, blue)
+}
+
+func TestNormalizeReadsAnICOWithABitmapPayload(t *testing.T) {
+	normalized, err := favicon.Normalize(icoWithPayload(16, 16, 32, dibPayload(16, red)))
+	if err != nil {
+		t.Fatalf("normalize a bitmap ico: %v", err)
+	}
+	assertColor(t, decodePNG(t, normalized), 32, 32, red)
+}
+
+// The directory can hold several sizes of the same icon. The one that needs the
+// least resampling to reach the served size should win, and a payload this
+// cannot read must not cost the file its other entries.
+func TestNormalizePrefersTheUsableEntryClosestToTheServedSize(t *testing.T) {
+	small := solidPNG(t, 16, 16, red)
+	right := solidPNG(t, 64, 64, blue)
+
+	out := make([]byte, 0)
+	out = append(out, 0, 0, 1, 0, 3, 0)
+	offsets := []int{6 + 3*16, 6 + 3*16 + len(small), 6 + 3*16 + len(small) + len(right)}
+	svg := []byte(`<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256"/>`)
+	entries := []struct {
+		edge   int
+		length int
+		offset int
+	}{
+		{16, len(small), offsets[0]},
+		{64, len(right), offsets[1]},
+		{0, len(svg), offsets[2]}, // 0 means 256 px — the biggest, and unreadable
+	}
+	for _, entry := range entries {
+		out = append(out, byte(entry.edge), byte(entry.edge), 0, 0)
+		out = binary.LittleEndian.AppendUint16(out, 1)
+		out = binary.LittleEndian.AppendUint16(out, 32)
+		out = binary.LittleEndian.AppendUint32(out, uint32(entry.length))
+		out = binary.LittleEndian.AppendUint32(out, uint32(entry.offset))
+	}
+	out = append(out, small...)
+	out = append(out, right...)
+	out = append(out, svg...)
+
+	normalized, err := favicon.Normalize(out)
+	if err != nil {
+		t.Fatalf("normalize a multi-size ico: %v", err)
+	}
+	// The 64px entry, not the 256px one it cannot read and not the 16px one.
+	assertColor(t, decodePNG(t, normalized), 32, 32, blue)
+}
+
+func TestNormalizeRefusesABrokenICO(t *testing.T) {
+	cases := map[string][]byte{
+		"a truncated directory":                      {0, 0, 1, 0, 4, 0, 0, 0},
+		"an entry pointing past the end of the file": icoWithPayload(16, 16, 32, nil),
+		"a payload that is neither png nor dib":      icoWithPayload(16, 16, 32, []byte("not an icon at all")),
+	}
+	for name, raw := range cases {
+		if _, err := favicon.Normalize(raw); err == nil {
+			t.Fatalf("normalizing %s should have failed", name)
+		}
+	}
+}

--- a/backend/internal/http/favicons_internal_test.go
+++ b/backend/internal/http/favicons_internal_test.go
@@ -1,0 +1,179 @@
+package httpapi
+
+// The board's icons, from the server's side: the rows it hands out point at
+// this origin, the route serves the stored file, and neither depends on a
+// database — so these run everywhere, unlike the MariaDB-backed suite.
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"makefaster/internal/favicon"
+	"makefaster/internal/leaderboard"
+)
+
+// iconPNG is what an origin serves: a plain square, larger than the board draws.
+func iconPNG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewNRGBA(image.Rect(0, 0, 128, 128))
+	draw.Draw(img, img.Bounds(), &image.Uniform{color.NRGBA{R: 0x20, G: 0x80, B: 0xff, A: 0xff}}, image.Point{}, draw.Src)
+	var out bytes.Buffer
+	if err := png.Encode(&out, img); err != nil {
+		t.Fatalf("encode icon: %v", err)
+	}
+	return out.Bytes()
+}
+
+// iconOrigin is the third-party host a favicon URL points at, counting how
+// often it is actually asked.
+func iconOrigin(t *testing.T) (string, *atomic.Int64) {
+	t.Helper()
+	hits := &atomic.Int64{}
+	body := iconPNG(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.Header().Set("content-type", "image/png")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(server.Close)
+	return server.URL + "/favicon.ico", hits
+}
+
+func testCache(t *testing.T, source string) *favicon.Cache {
+	t.Helper()
+	cache, err := favicon.New(favicon.Options{
+		Dir:               filepath.Join(t.TempDir(), "favicons"),
+		AllowPrivateHosts: true,
+		Resolver: func(context.Context, string) (string, error) {
+			return source, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("new favicon cache: %v", err)
+	}
+	return cache
+}
+
+// spaFixture is a minimal SPA root, so a request that falls through to the
+// static handler behaves the way it does in a deploy.
+func spaFixture(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "index.html"), []byte("<app-root></app-root>"), 0o644); err != nil {
+		t.Fatalf("write index.html: %v", err)
+	}
+	return dir
+}
+
+// The rows the board reads carry a path on this server, and keep the origin's
+// URL only as the thing that path was derived from.
+func TestSiteRowsPointAtThisServersCopyOfTheIcon(t *testing.T) {
+	source, hits := iconOrigin(t)
+	cache := testCache(t, source)
+	server := NewServer(Options{FrontendDir: spaFixture(t), Favicons: cache})
+
+	rows := server.withServedFavicons([]leaderboard.SiteRow{
+		{URL: "example.com", Favicon: source},
+		{URL: "plain.dev"},
+		{URL: "bad.dev", Favicon: "javascript:alert(1)"},
+	})
+
+	if !strings.HasPrefix(rows[0].FaviconPath, favicon.URLPrefix) {
+		t.Fatalf("faviconPath is %q, want a path under %s", rows[0].FaviconPath, favicon.URLPrefix)
+	}
+	if rows[0].Favicon != source {
+		t.Fatalf("the original favicon URL was rewritten to %q", rows[0].Favicon)
+	}
+	if rows[1].FaviconPath != "" || rows[2].FaviconPath != "" {
+		t.Fatalf("a row with no usable favicon got %q / %q", rows[1].FaviconPath, rows[2].FaviconPath)
+	}
+
+	// Rendering the board started the download without waiting for it.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if hits.Load() > 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("a board render never started the download")
+}
+
+// A deployment that caches no icons publishes no path either. The board draws
+// letters; it does not fall back to loading the third-party URL.
+func TestSiteRowsCarryNoPathWithoutACache(t *testing.T) {
+	server := NewServer(Options{FrontendDir: spaFixture(t)})
+	rows := server.withServedFavicons([]leaderboard.SiteRow{{URL: "example.com", Favicon: "https://example.com/favicon.ico"}})
+	if rows[0].FaviconPath != "" {
+		t.Fatalf("faviconPath is %q, want empty", rows[0].FaviconPath)
+	}
+}
+
+func TestFaviconRouteServesTheNormalizedIcon(t *testing.T) {
+	source, _ := iconOrigin(t)
+	cache := testCache(t, source)
+	server := NewServer(Options{FrontendDir: spaFixture(t), Favicons: cache})
+	front := httptest.NewServer(server.Handler())
+	t.Cleanup(front.Close)
+
+	path := cache.Path("example.com", source)
+	response, err := http.Get(front.URL + path)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s answered %d", path, response.StatusCode)
+	}
+	if contentType := response.Header.Get("content-type"); contentType != "image/png" {
+		t.Fatalf("content-type is %q, want image/png", contentType)
+	}
+	if cacheControl := response.Header.Get("cache-control"); !strings.Contains(cacheControl, "max-age=") {
+		t.Fatalf("cache-control is %q, want a max-age", cacheControl)
+	}
+	decoded, err := png.Decode(response.Body)
+	if err != nil {
+		t.Fatalf("the served bytes are not a png: %v", err)
+	}
+	if decoded.Bounds().Dx() != favicon.Size {
+		t.Fatalf("served a %dpx icon, want %d", decoded.Bounds().Dx(), favicon.Size)
+	}
+}
+
+// An icon path must never be answered with the SPA shell: a broken <img> is a
+// letter fallback, but an <img> pointing at HTML is a broken image forever.
+func TestFaviconPathsNeverFallBackToTheShell(t *testing.T) {
+	for name, options := range map[string]Options{
+		"with no cache configured": {FrontendDir: spaFixture(t)},
+		"with a cache":             {FrontendDir: spaFixture(t), Favicons: testCache(t, "")},
+	} {
+		front := httptest.NewServer(NewServer(options).Handler())
+		response, err := http.Get(front.URL + favicon.URLPrefix + "example.com-0123456789.png")
+		if err != nil {
+			t.Fatalf("%s: GET an unknown icon: %v", name, err)
+		}
+		body := make([]byte, 64)
+		read, _ := response.Body.Read(body)
+		response.Body.Close()
+		front.Close()
+
+		if response.StatusCode != http.StatusNotFound {
+			t.Fatalf("%s: answered %d, want 404", name, response.StatusCode)
+		}
+		if strings.Contains(string(body[:read]), "app-root") {
+			t.Fatalf("%s: answered with the SPA shell", name)
+		}
+	}
+}

--- a/backend/internal/http/favicons_test.go
+++ b/backend/internal/http/favicons_test.go
@@ -1,0 +1,210 @@
+package httpapi_test
+
+// The whole favicon path, end to end against the database: a submission names
+// an icon on a host that refuses hotlinked requests, and the board still gets a
+// picture — from this server, at this server's size.
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"image"
+	"image/color"
+	"image/draw"
+	"image/png"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"makefaster/internal/embedding"
+	"makefaster/internal/favicon"
+	httpapi "makefaster/internal/http"
+	"makefaster/internal/leaderboard"
+	"makefaster/internal/store"
+)
+
+// hotlinkingOrigin is a site that serves its favicon to a direct request and
+// refuses one that came from a page on another domain — the exact behaviour the
+// board's third-party <img src> used to trip over.
+func hotlinkingOrigin(t *testing.T) *httptest.Server {
+	t.Helper()
+	icon := image.NewNRGBA(image.Rect(0, 0, 180, 180))
+	draw.Draw(icon, icon.Bounds(), &image.Uniform{color.NRGBA{R: 0xd9, G: 0x3a, B: 0x1f, A: 0xff}}, image.Point{}, draw.Src)
+	var body bytes.Buffer
+	if err := png.Encode(&body, icon); err != nil {
+		t.Fatalf("encode the origin's icon: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("referer") != "" || r.Header.Get("origin") != "" {
+			http.Error(w, "hotlinking is not allowed", http.StatusForbidden)
+			return
+		}
+		w.Header().Set("content-type", "image/png")
+		_, _ = w.Write(body.Bytes())
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+// bootWithFavicons is `boot` plus the icon cache, rooted in a temporary
+// directory. AllowPrivateHosts is what lets the test's own origin stand in for
+// a real one; the deploy leaves it off.
+func bootWithFavicons(t *testing.T, pool *sql.DB) *httptest.Server {
+	t.Helper()
+	leaderboards := store.New(pool)
+	if err := leaderboards.Seed(context.Background(), fixtureSeedDir()); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	cache, err := favicon.New(favicon.Options{
+		Dir:               filepath.Join(t.TempDir(), "favicons"),
+		Resolver:          leaderboards.SiteFavicon,
+		AllowPrivateHosts: true,
+	})
+	if err != nil {
+		t.Fatalf("new favicon cache: %v", err)
+	}
+
+	embedder, threshold := embedding.New(embedding.Options{}, nil)
+	server := httpapi.NewServer(httpapi.Options{
+		Store:       leaderboards,
+		Embedder:    embedder,
+		Threshold:   threshold,
+		FrontendDir: frontendFixture(t),
+		Favicons:    cache,
+	})
+	httpServer := httptest.NewServer(server.Handler())
+	t.Cleanup(httpServer.Close)
+	return httpServer
+}
+
+// waitForIcon retries the icon URL while the background download that a
+// submission started finishes. A board render never waits like this — it draws
+// the letter and moves on — but a test has to.
+func waitForIcon(t *testing.T, url string) *http.Response {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		response, err := http.Get(url)
+		if err != nil {
+			t.Fatalf("GET %s: %v", url, err)
+		}
+		if response.StatusCode == http.StatusOK || time.Now().After(deadline) {
+			return response
+		}
+		response.Body.Close()
+		time.Sleep(20 * time.Millisecond)
+	}
+}
+
+func TestSubmittedFaviconIsServedFromThisOrigin(t *testing.T) {
+	pool := freshDatabase(t)
+	server := bootWithFavicons(t, pool)
+	origin := hotlinkingOrigin(t)
+	iconURL := origin.URL + "/favicon.ico"
+
+	// The premise: a browser loading this icon from a page on the board's
+	// domain is refused, which is why the board cannot use the URL directly.
+	request, _ := http.NewRequest(http.MethodGet, iconURL, nil)
+	request.Header.Set("referer", server.URL+"/site-leaderboard")
+	refused, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET the origin's icon as a hotlink: %v", err)
+	}
+	refused.Body.Close()
+	if refused.StatusCode != http.StatusForbidden {
+		t.Fatalf("the origin answered %d; this test needs it to refuse hotlinks", refused.StatusCode)
+	}
+
+	submission, err := json.Marshal(map[string]any{
+		"url": "hotlinked.dev", "mode": "cold", "favicon": iconURL,
+		"lcpRaw": 1800, "lcpDelta": -30, "ttiRaw": 2400, "ttiDelta": -25,
+	})
+	if err != nil {
+		t.Fatalf("encode the submission: %v", err)
+	}
+	var accepted struct {
+		Row leaderboard.SiteRow `json:"row"`
+	}
+	if status := postJSON(t, server.URL+"/api/submit-site", string(submission), &accepted); status != http.StatusCreated {
+		t.Fatalf("submit answered %d, want 201", status)
+	}
+	if accepted.Row.Favicon != iconURL {
+		t.Fatalf("the row's favicon is %q, want the submitted URL", accepted.Row.Favicon)
+	}
+	if !strings.HasPrefix(accepted.Row.FaviconPath, favicon.URLPrefix) {
+		t.Fatalf("the row's faviconPath is %q, want a path on this server", accepted.Row.FaviconPath)
+	}
+
+	// The board reads the rows and only ever gets a path on this server.
+	var rows []leaderboard.SiteRow
+	if status := getJSON(t, server.URL+"/data/sites.json", &rows); status != http.StatusOK {
+		t.Fatalf("GET /data/sites.json answered %d", status)
+	}
+	var row *leaderboard.SiteRow
+	for index := range rows {
+		if rows[index].URL == "hotlinked.dev" {
+			row = &rows[index]
+		}
+	}
+	if row == nil {
+		t.Fatal("the submitted site is not on the board")
+	}
+	if row.FaviconPath != accepted.Row.FaviconPath {
+		t.Fatalf("the board's path is %q, the submission's was %q", row.FaviconPath, accepted.Row.FaviconPath)
+	}
+	if strings.Contains(row.FaviconPath, origin.URL) {
+		t.Fatalf("the board's path %q points at the third-party origin", row.FaviconPath)
+	}
+
+	response := waitForIcon(t, server.URL+row.FaviconPath)
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s answered %d", row.FaviconPath, response.StatusCode)
+	}
+	if contentType := response.Header.Get("content-type"); contentType != "image/png" {
+		t.Fatalf("content-type is %q, want image/png", contentType)
+	}
+	decoded, err := png.Decode(response.Body)
+	if err != nil {
+		t.Fatalf("the served icon is not a png: %v", err)
+	}
+	if decoded.Bounds().Dx() != favicon.Size || decoded.Bounds().Dy() != favicon.Size {
+		t.Fatalf("served a %dx%d icon, want %d square",
+			decoded.Bounds().Dx(), decoded.Bounds().Dy(), favicon.Size)
+	}
+}
+
+// A row with no favicon at all keeps rendering: no path, no icon request, and
+// the board's letter fallback.
+func TestRowsWithoutAFaviconAreLeftAlone(t *testing.T) {
+	pool := freshDatabase(t)
+	server := bootWithFavicons(t, pool)
+	if _, err := pool.Exec("UPDATE sites SET favicon = ''"); err != nil {
+		t.Fatalf("clear the seeded favicons: %v", err)
+	}
+
+	var rows []leaderboard.SiteRow
+	if status := getJSON(t, server.URL+"/data/sites.json", &rows); status != http.StatusOK {
+		t.Fatalf("GET /data/sites.json answered %d", status)
+	}
+	if len(rows) == 0 {
+		t.Fatal("the seeded board is empty")
+	}
+	for _, row := range rows {
+		if row.FaviconPath != "" {
+			t.Fatalf("%s has no favicon but got the path %q", row.URL, row.FaviconPath)
+		}
+	}
+
+	// And the key is absent from the JSON rather than present and empty, so a
+	// client that predates the field sees exactly what it always did.
+	raw, _ := json.Marshal(rows[0])
+	if bytes.Contains(raw, []byte("faviconPath")) {
+		t.Fatalf("a row with no icon still carries faviconPath: %s", raw)
+	}
+}

--- a/backend/internal/http/server.go
+++ b/backend/internal/http/server.go
@@ -7,6 +7,8 @@
 //	GET  /                          the SPA shell (and every unknown app route)
 //	GET  /data/sites.json           live site-leaderboard rows
 //	GET  /data/improvements.json    live improvement categories
+//	GET  /favicons/<site>-<id>.png  a site's favicon, downloaded from its own
+//	                                origin once and normalized (internal/favicon)
 //	GET  /api/health                { ok, embedder, threshold, inference }
 //	POST /api/submit-site           one measurement run for one site, plus
 //	                                optional private tips for the catalog
@@ -35,6 +37,7 @@ import (
 	"time"
 
 	"makefaster/internal/embedding"
+	"makefaster/internal/favicon"
 	"makefaster/internal/inference"
 	"makefaster/internal/leaderboard"
 	"makefaster/internal/store"
@@ -76,6 +79,11 @@ type Server struct {
 	// deployment collects no traces and POST /api/submit-trace answers 503.
 	traces *trace.Vault
 
+	// favicons downloads and serves the site icons the board shows. Nil is a
+	// supported state too: no /favicons/ route, no faviconPath on the rows, and
+	// the board draws each site's initial instead.
+	favicons *favicon.Cache
+
 	limiter          *rateLimiter
 	inferenceLimiter *rateLimiter
 
@@ -99,6 +107,10 @@ type Options struct {
 	// Traces is optional in the same way: a nil vault means this deployment
 	// stores no chains of thought, and says so.
 	Traces *trace.Vault
+
+	// Favicons is optional: a nil cache means the board renders letters
+	// instead of icons. It never means the page falls back to hotlinking.
+	Favicons *favicon.Cache
 }
 
 func NewServer(opts Options) *Server {
@@ -118,6 +130,7 @@ func NewServer(opts Options) *Server {
 		logger:           logger,
 		inference:        proxy,
 		traces:           opts.Traces,
+		favicons:         opts.Favicons,
 		limiter:          newRateLimiter(rateLimitMaxPosts),
 		inferenceLimiter: newRateLimiter(inferenceRateLimitMax),
 	}
@@ -173,6 +186,13 @@ func (s *Server) route(w http.ResponseWriter, r *http.Request) {
 				},
 			})
 		default:
+			// The board's icons: this server's own copies, so the page never
+			// loads an image from a third-party origin that may refuse it.
+			if s.favicons != nil && strings.HasPrefix(r.URL.Path, favicon.URLPrefix) {
+				s.favicons.ServeHTTP(w, r)
+				return
+			}
+
 			// Everything under /api/ that is not a route above is a 404, not
 			// the SPA shell. The write endpoints store things that are never
 			// meant to be read back — private catalog tips, chains of thought —
@@ -212,7 +232,34 @@ func (s *Server) handleSites(w http.ResponseWriter, r *http.Request) {
 		s.fail(w, err)
 		return
 	}
-	s.writeJSON(w, http.StatusOK, rows)
+	s.writeJSON(w, http.StatusOK, s.withServedFavicons(rows))
+}
+
+// withServedFavicons points each row at this server's own copy of its icon and
+// starts the download for the ones that are missing or stale.
+//
+// The response is not allowed to wait on any of that: priming is
+// fire-and-forget, so a board render costs the same whether every icon is
+// already stored or none of them are. A row whose icon has not landed yet gets
+// a 404 from the favicon route and draws its letter, and the next render — or
+// the browser's own request for the image — picks up the stored file.
+//
+// The original URL stays on the row as `favicon`. It is what the download is
+// derived from and what the CLI has always seen; it is simply not what the page
+// loads any more.
+func (s *Server) withServedFavicons(rows []leaderboard.SiteRow) []leaderboard.SiteRow {
+	if s.favicons == nil {
+		return rows
+	}
+	for index := range rows {
+		path := s.favicons.Path(rows[index].URL, rows[index].Favicon)
+		if path == "" {
+			continue
+		}
+		rows[index].FaviconPath = path
+		s.favicons.Prime(rows[index].URL, rows[index].Favicon)
+	}
+	return rows
 }
 
 func (s *Server) handleImprovements(w http.ResponseWriter, r *http.Request) {
@@ -258,6 +305,15 @@ func (s *Server) handleSubmitSite(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		s.fail(w, err)
 		return
+	}
+
+	// Ingest is the first moment the icon's URL is known, so the download
+	// starts here rather than waiting for somebody to load the board. It runs
+	// in the background: a submission is acknowledged on the strength of its
+	// measurement, never on whether an origin served its favicon.
+	if s.favicons != nil {
+		s.favicons.Prime(row.URL, row.Favicon)
+		row.FaviconPath = s.favicons.Path(row.URL, row.Favicon)
 	}
 
 	// Tips ride along with the submission but are not part of it: the site row

--- a/backend/internal/leaderboard/model.go
+++ b/backend/internal/leaderboard/model.go
@@ -32,6 +32,14 @@ func FormatTimestamp(t time.Time) string {
 // the JSON when there is none: most rows predate the field, and a row without a
 // PR must not render a dead link.
 //
+// Favicon is the icon's URL at its own origin, as submitted or derived, and it
+// is not what the board loads: FaviconPath is the same-origin path this server
+// serves a downloaded, normalized copy from (see internal/favicon). It is
+// filled in on the way out of GET /data/sites.json rather than stored, and is
+// absent when this deployment caches no icons or the row's URL is not one the
+// server will fetch — in which case the board draws the site's initial rather
+// than hotlinking an origin that may well refuse the request.
+//
 // GenericKeepPct / SiteSpecificKeepPct split the run's kept changes into the
 // ones that were reusable techniques and the ones that were only ever going to
 // matter to this site. They sum to 100 when the run kept anything, and are both
@@ -44,6 +52,7 @@ type SiteRow struct {
 	GenericKeepPct      int     `json:"genericKeepPct,omitempty"`
 	SiteSpecificKeepPct int     `json:"siteSpecificKeepPct,omitempty"`
 	Favicon             string  `json:"favicon"`
+	FaviconPath         string  `json:"faviconPath,omitempty"`
 	LCPBefore           int     `json:"lcpBefore"`
 	LCPRaw              int     `json:"lcpRaw"`
 	LCPDelta            float64 `json:"lcpDelta"`

--- a/backend/internal/store/store.go
+++ b/backend/internal/store/store.go
@@ -58,6 +58,27 @@ func (s *Store) Sites(ctx context.Context) ([]leaderboard.SiteRow, error) {
 	return out, rows.Err()
 }
 
+// SiteFavicon returns the favicon URL recorded for one site, or "" when the
+// board has no row for it or the row carries none. A site measured both cold
+// and warm has one row per mode and the same icon on each, so the first row
+// wins.
+//
+// This is what the favicon route resolves a requested path against: the served
+// file's name carries a digest of this URL, so a row that starts pointing
+// somewhere else stops matching the old path instead of serving a stale icon.
+func (s *Store) SiteFavicon(ctx context.Context, host string) (string, error) {
+	var favicon string
+	err := s.db.QueryRowContext(ctx,
+		"SELECT favicon FROM sites WHERE url = ? AND favicon <> '' ORDER BY id LIMIT 1", host).Scan(&favicon)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("query site favicon: %w", err)
+	}
+	return favicon, nil
+}
+
 // Categories returns the improvement leaderboard in rank order.
 func (s *Store) Categories(ctx context.Context) ([]leaderboard.Category, error) {
 	rows, err := s.db.QueryContext(ctx, "SELECT `rank`, name, description, `count`, avg_improvement_ms, avg_improvement_pct, icon "+

--- a/env.example
+++ b/env.example
@@ -45,6 +45,25 @@ FRONTEND_DIR=../frontend
 # The process needs write access to the parent directory.
 # MAKEFASTER_TRACE_DIR=/var/lib/makefaster/traces
 
+# ------------------------------------------------------------- site favicons
+
+# Where the site leaderboard's icons are stored. The server downloads each
+# site's favicon from its own origin once, converts it to a single small square
+# PNG, and serves it from /favicons/… so the board loads images from this
+# origin only — a third-party <img> src is what CORS and hotlink protection
+# broke. Outside the repo and outside FRONTEND_DIR on purpose: a git pull must
+# not be able to clobber the cache, and the static handler must not be able to
+# serve whatever else lands in it.
+#
+# A directory that cannot be created falls back to a cache under the system
+# temporary directory — these files are re-downloadable, so losing them on a
+# reboot costs one background fetch per site. Set this to keep them.
+#
+# Set to "off" (or empty) to cache nothing: the route disappears and the board
+# renders each site's initial, which is what a row with no favicon already
+# does. It never falls back to hotlinking.
+# MAKEFASTER_FAVICON_DIR=/var/lib/makefaster/favicons
+
 # --------------------------------------------------------------- embeddings
 
 # Unset: the deterministic local feature-hashing embedder (no network, no key,

--- a/frontend/js/api.js
+++ b/frontend/js/api.js
@@ -23,7 +23,11 @@ const DATA_PATHS = {
   improvements: "/data/improvements.json",
 };
 
-function apiBase() {
+/**
+ * The API origin, empty when the SPA and the server are the same host. Also
+ * used for the favicons the server serves alongside the data endpoints.
+ */
+export function apiBase() {
   return (window.MAKEFASTER_API_BASE || "").replace(/\/$/, "");
 }
 
@@ -56,9 +60,11 @@ function postJson(path, payload) {
 
 /**
  * Site leaderboard rows.
- * Row shape: { name, url, favicon, lcpBefore, lcpRaw, lcpDelta, ttiBefore,
- *              ttiRaw, ttiDelta, mode, tests, measuredAt, prUrl?,
+ * Row shape: { name, url, favicon, faviconPath?, lcpBefore, lcpRaw, lcpDelta,
+ *              ttiBefore, ttiRaw, ttiDelta, mode, tests, measuredAt, prUrl?,
  *              genericKeepPct?, siteSpecificKeepPct? }
+ * favicon is the icon at its own origin; faviconPath is this server's
+ * normalized copy of it, and the only one the board loads (see favicon.js).
  * lcpDelta / ttiDelta are percentages vs. baseline (negative = faster).
  * mode is "cold" or "warm".
  * prUrl is the pull request the run was opened as, absent when there is none.

--- a/frontend/js/favicon.js
+++ b/frontend/js/favicon.js
@@ -1,0 +1,35 @@
+/**
+ * Where the site leaderboard loads a row's icon from.
+ *
+ * Never the origin's own URL. The board used to point <img src> straight at
+ * `row.favicon`, which is a third-party URL, and the sites that answer it with
+ * hotlink protection or a cross-origin refusal showed a broken image. The
+ * server now downloads each icon once, normalizes it, and serves it from its
+ * own origin as `row.faviconPath`; this module is the rule that the page only
+ * ever asks for that.
+ *
+ * A row without a served path — no favicon, a URL the server would not fetch,
+ * or a deployment that caches none — gets "" and keeps the letter fallback.
+ */
+
+// The exact shape the server hands out (internal/favicon): the icons route,
+// then one file name of hostname, digest and extension. Matching it strictly is
+// what keeps a stored value from turning into a request to somewhere else: an
+// absolute URL, a protocol-relative "//evil.example", or a javascript: URL all
+// fail here rather than reaching an <img>.
+const SERVED_PATH = /^\/favicons\/[a-z0-9][a-z0-9.-]*-[0-9a-f]+\.png$/;
+
+/**
+ * The image URL for a board row, or "" when there is none to load.
+ *
+ * `base` is the API origin when the SPA is hosted apart from the server
+ * (window.MAKEFASTER_API_BASE); the icons are served by the same process as
+ * /data/sites.json, so they hang off the same base.
+ */
+export function faviconSrc(row, base) {
+  if (!row || typeof row.faviconPath !== "string") return "";
+  var path = row.faviconPath;
+  if (!SERVED_PATH.test(path)) return "";
+  var origin = typeof base === "string" ? base.replace(/\/$/, "") : "";
+  return origin + path;
+}

--- a/frontend/js/site-leaderboard-page.js
+++ b/frontend/js/site-leaderboard-page.js
@@ -6,7 +6,8 @@
  */
 import "./site-header.js";
 import "./spec-footer.js";
-import { getSites } from "./api.js";
+import { apiBase, getSites } from "./api.js";
+import { faviconSrc } from "./favicon.js";
 import { escapeHtml, renderPagination } from "./format.js";
 import { nextSort, sortRows, sortableHeader } from "./table-sort.js";
 
@@ -327,19 +328,28 @@ class SiteLeaderboardPage extends HTMLElement {
     }
   }
 
+  /**
+   * The site's icon, always loaded from this server's own copy — never from the
+   * site's origin, which is where the broken images came from: plenty of hosts
+   * refuse an image request that comes from a page on another domain.
+   *
+   * A row with no served copy yet (the server downloads it in the background on
+   * first sight) or none possible falls back to the site's initial, which is
+   * also what an image that fails to decode lands on.
+   */
   faviconCell(row) {
     var box = document.createElement("div");
     box.className = "favicon-box";
     var letter = ((row.name || row.url || "?").trim()[0] || "?").toUpperCase();
-    if (row.favicon) {
+    var src = faviconSrc(row, apiBase());
+    if (src) {
       var img = document.createElement("img");
       img.alt = "";
       img.loading = "lazy";
-      img.referrerPolicy = "no-referrer";
       img.addEventListener("error", function () {
         box.innerHTML = '<div class="favicon-fallback">' + escapeHtml(letter) + "</div>";
       });
-      img.src = row.favicon;
+      img.src = src;
       box.appendChild(img);
     } else {
       box.innerHTML = '<div class="favicon-fallback">' + escapeHtml(letter) + "</div>";

--- a/frontend/test/favicon.test.mjs
+++ b/frontend/test/favicon.test.mjs
@@ -1,0 +1,56 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { faviconSrc } from "../js/favicon.js";
+
+/* A row as GET /data/sites.json hands it over: the origin's URL, plus the path
+   this server serves its own normalized copy from. */
+const ROW = {
+  name: "Example",
+  url: "example.com",
+  favicon: "https://cdn.example.com/favicon.ico",
+  faviconPath: "/favicons/example.com-1a2b3c4d5e.png",
+};
+
+// The bug this replaced: pointing <img src> at row.favicon, which plenty of
+// hosts refuse once the request comes from another domain.
+test("the icon is loaded from this server, never from the site's own origin", () => {
+  assert.equal(faviconSrc(ROW, ""), "/favicons/example.com-1a2b3c4d5e.png");
+  assert.ok(!faviconSrc(ROW, "").includes("cdn.example.com"));
+});
+
+test("a row the server has no copy for falls back to the letter", () => {
+  // No served path at all — the row has no favicon, or one the server will not
+  // fetch. Either way the caller gets "" and draws the site's initial.
+  assert.equal(faviconSrc({ url: "example.com" }, ""), "");
+  assert.equal(faviconSrc({ url: "example.com", faviconPath: "" }, ""), "");
+  assert.equal(faviconSrc(null, ""), "");
+  // And the third-party URL on its own is never enough to load an image.
+  assert.equal(faviconSrc({ url: "example.com", favicon: ROW.favicon }, ""), "");
+});
+
+// The rows are stored data rendered into a page, so the path is matched against
+// the shape the server hands out rather than trusted.
+test("only the server's own icon path is ever loaded", () => {
+  const rejected = [
+    "https://evil.example/favicon.png",
+    "//evil.example/favicon.png",
+    "javascript:alert(1)",
+    "data:image/png;base64,iVBORw0K",
+    "/favicons/../../etc/passwd",
+    "/favicons/example.com-1a2b3c4d5e.svg",
+    "/favicons/example.com.png",
+    "/data/sites.json",
+    "/favicons/",
+  ];
+  for (const faviconPath of rejected) {
+    assert.equal(faviconSrc({ url: "example.com", faviconPath }, ""), "", faviconPath);
+  }
+});
+
+// The icons come from the same process as /data/sites.json, so a separately
+// hosted SPA has to ask that origin for them too.
+test("a separately hosted SPA loads the icon from the API origin", () => {
+  assert.equal(faviconSrc(ROW, "https://api.example.dev"), "https://api.example.dev" + ROW.faviconPath);
+  assert.equal(faviconSrc(ROW, "https://api.example.dev/"), "https://api.example.dev" + ROW.faviconPath);
+  assert.equal(faviconSrc(ROW, undefined), ROW.faviconPath);
+});

--- a/packages/skill/SKILL.md
+++ b/packages/skill/SKILL.md
@@ -636,7 +636,10 @@ Field notes:
   row's name to it, so a reader can go from the number to the diff. Leave it
   out if there is no PR; the row simply will not be a link.
 - `site.favicon` — a favicon URL if the site has one (`<link rel="icon">` or
-  `/favicon.ico`); it is shown next to the URL on the site leaderboard.
+  `/favicon.ico`); it is shown next to the URL on the site leaderboard. The
+  server downloads it once and serves its own converted copy, so a host that
+  blocks hotlinking is fine — prefer a raster icon (ICO, PNG) over an SVG one,
+  which the board cannot convert and falls back to the site's initial for.
 - `baseline` / `final` — medians per mode. Include the modes you measured;
   `lcpMs` and `ttiMs` are required per included mode (they feed the site
   leaderboard), `fcpMs` / `tbtMs` / `cls` / `score` (0-100 performance score)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The board pointed `<img src>` straight at `row.favicon` — a URL on somebody else's server — and the hosts that refuse a cross-origin image request left a broken picture where an icon belonged. The server now keeps its own copy.

Rebased onto `main` (f1a779a, i.e. after #14). The only conflict was the import block in `frontend/js/site-leaderboard-page.js`; #14's trims — the CSV export, `geo-row`, the `.eyebrow` line, `keepSplitMarkup` — all stay removed, and `faviconCell` is the only thing this branch touches in that file.

## Verified in the browser

Against a local MariaDB and a seed of four real favicon URLs. First render: the board draws letters and the `/favicons/` requests 404, because nothing waits on a download. After a reload the GitHub and Cursor icons are served from `127.0.0.1:8899` as PNG with `cache-control: public, max-age=86400`, and `go.dev` — whose favicon is an SVG — keeps its letter.

[favicons_first_render_falls_back_then_serves_from_this_origin.mp4](https://cursor.com/agents/bc-0c79c0bd-95e3-4ee6-b5db-7fbdafdf3224/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffavicons_first_render_falls_back_then_serves_from_this_origin.mp4)

The same board re-checked after the rebase, with #14's trims intact:

[The rebased site leaderboard: no eyebrow line, no Export CSV button, GitHub and Cursor favicons served from /favicons/, letter fallbacks for go.dev and a row with no favicon](https://cursor.com/agents/bc-0c79c0bd-95e3-4ee6-b5db-7fbdafdf3224/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_board_after_rebase_onto_main.webp)

## What changed

**`backend/internal/favicon`** (new) downloads a site's icon once, normalizes it, stores it, and serves it:

- **64px square PNG**, fitted and centred on transparency so a wide icon is not stretched. That is the size the board's 28px `.favicon-box` draws at 26px, with pixels to spare on a 2x display.
- **Reads what favicon URLs actually answer with**: PNG, JPEG, GIF, and the ICO container — including the headerless Windows bitmaps inside it (1/4/8/24/32 bpp with the AND mask), which the standard library has no decoder for. Multi-size ICOs pick the entry closest to the served size and fall through to the next one when a payload is unreadable. No new dependencies.
- **Served from `/favicons/<host>-<digest of the source URL>.png`** with a day-long `max-age`, same origin as the board, so no CORS and no referrer policy is involved. The digest in the name is what makes a row that starts pointing at a different icon get a different path instead of a stale file; the superseded file is dropped when the new one lands.
- **Stored under `MAKEFASTER_FAVICON_DIR`** (default `/var/lib/makefaster/favicons`), outside the repo and outside `FRONTEND_DIR`, so a git pull cannot clobber the cache and the static handler cannot serve whatever else lands in it. An unwritable directory falls back to one under the system temp dir rather than dropping every icon — the files are re-downloadable. `off` disables the feature: letters on the board, never a hotlink.
- **Refuses non-public addresses.** The favicon URL arrives through a public write endpoint, so a server that will fetch `http://169.254.169.254/…` on request is an SSRF hole. The check runs on the resolved address, so it survives a hostname pointing at loopback and a redirect chain ending there. Also capped: 1 MB body, 8s timeout, 3 redirects, `http(s)` only.

**Nothing blocks on a download.** `GET /data/sites.json` fills in the new `faviconPath` on each row and starts the fetches it needs fire-and-forget, so a board render costs the same whether every icon is stored or none are. Ingest primes it too, since `POST /api/submit-site` is the first moment the URL is known. A row whose icon has not landed yet gets a 404 and draws the site's initial — the fallback `faviconCell` already had. A failed URL is left alone for ten minutes instead of retried on every render; a stored icon refreshes in the background after two weeks while the old one keeps being served; concurrent viewers share one download.

**The page only ever asks this origin.** `frontend/js/favicon.js` matches `faviconPath` against the exact shape the server hands out and returns `""` for anything else, so a stored value cannot turn into a request to another host. The row keeps its original `favicon` URL in the JSON — it is what the download is derived from and what the CLI has always seen — it is simply not what the page loads.

## Tests

`go test ./...` and `npm test` both pass on the rebased tree, including the MariaDB-backed suite (run against a local MariaDB) and `-race`.

- **`internal/favicon`** (21 tests) serves its own origin with `httptest` and never touches the internet: unfetchable URLs, an origin that refuses the request, an origin that answers 200 with an HTML page, a successful convert down to the served pixels, a second request that is a file read rather than a second download, paths the cache never issued (traversal, wrong digest, bad extension), a stale file served while it refreshes behind the request, eight concurrent viewers sharing one download, the private-address guard refusing a loopback origin, and the ICO/DIB decoders.
- **`internal/http`** covers the route and the row decoration with no database at all, plus an end-to-end test against a stub origin that returns 403 to any request carrying a `Referer`: the hotlink refusal is asserted first, then the submission, then the board's row, then the 64px PNG served from this origin.
- **`frontend/test/favicon.test.mjs`** pins the rule that the third-party URL is never loaded and that only the server's own path shape is accepted.

Docs: `MAKEFASTER_FAVICON_DIR` in `env.example` and the config table, a `### Site favicons` section in the README, plus the route table, row shape, deploy notes, test list, and a note to submitters in `packages/skill/SKILL.md` that a raster favicon beats an SVG one.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0c79c0bd-95e3-4ee6-b5db-7fbdafdf3224?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0c79c0bd-95e3-4ee6-b5db-7fbdafdf3224&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

